### PR TITLE
Add invoice order status and update branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-All notable changes to the byPieroFracasso WooCommerce Emails plugin will be documented in this file.
+All notable changes to the Piero Fracasso Perfumes WooCommerce Emails plugin will be documented in this file.
+
+## [1.1.0] - 2025-09-08
+### Added
+  - Introduced custom `invoice` order status with bulk action support and automatic assignment for configured payment methods.
+### Changed
+  - Rebranded plugin strings to "Piero Fracasso Perfumes" and switched text domain to `piero-fracasso-emails`.
+  - Kept email item prices on one line and cleaned up label colons.
+  - Bumped plugin version to 1.1.0.
 
 ## [1.0.23] - 2025-04-11
 ### Fixed
@@ -33,9 +41,9 @@ All notable changes to the byPieroFracasso WooCommerce Emails plugin will be doc
   - Corrected template file paths in email classes (e.g., `customer-order-shipped.php`, `customer-order-ready-for-pickup.php`).
 - Fixed a fatal error in `email-order-items.php` by adding validation for invalid products (prevented `Call to a member function get_image_id() on bool`).
 ### Added
-- Added debug logging to track email triggers and status changes in `byPieroFracasso_WooCommerce_Emails.php` and `class-email-manager.php`.
+- Added debug logging to track email triggers and status changes in `Piero Fracasso Perfumes_WooCommerce_Emails.php` and `class-email-manager.php`.
 - Added `BPF_WC_Email_Customer_Processing_Order` class to prevent the "Customer Processing Order" email from sending unless the status is explicitly `processing`.
-- Added status protection in `byPieroFracasso_WooCommerce_Emails.php` to block automatic transitions to `processing` after `wc-received`.
+- Added status protection in `Piero Fracasso Perfumes_WooCommerce_Emails.php` to block automatic transitions to `processing` after `wc-received`.
 
 ## [1.0.19] - 2025-03-01 (Assumed)
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# byPieroFracasso WooCommerce Emails
+# Piero Fracasso Perfumes WooCommerce Emails
 
 ## Overview
-The **byPieroFracasso WooCommerce Emails** plugin is a custom WordPress plugin designed to enhance the email functionality of WooCommerce for the byPieroFracasso online store. It introduces custom order statuses, corresponding email notifications, and overrides default WooCommerce email templates with branded versions. The plugin also disables unnecessary default WooCommerce emails to streamline notifications.
+The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress plugin designed to enhance the email functionality of WooCommerce for the Piero Fracasso Perfumes online store. It introduces custom order statuses, corresponding email notifications, and overrides default WooCommerce email templates with branded versions. The plugin also disables unnecessary default WooCommerce emails to streamline notifications.
 
 ## Features
 - **Custom Order Statuses**:

--- a/bypierofracasso-woocommerce-emails.php
+++ b/bypierofracasso-woocommerce-emails.php
@@ -1,13 +1,13 @@
 <?php
 /*
-Plugin Name: byPieroFracasso WooCommerce Emails
+Plugin Name: Piero Fracasso Perfumes WooCommerce Emails
 Plugin URI: https://bypierofracasso.com/
 Description: Steuert alle WooCommerce-E-Mails und deaktiviert nicht benötigte Standardmails.
-Version: 1.0.23
-Author: byPieroFracasso
+Version: 1.1.0
+Author: Piero Fracasso Perfumes
 Author URI: https://bypierofracasso.com/
 License: GPLv2 or later
-Text Domain: bypierofracasso-woocommerce-emails
+Text Domain: piero-fracasso-emails
 Domain Path: /languages
 */
 
@@ -15,14 +15,14 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('BYPF_EMAILS_VERSION', '1.0.22');
+define('BYPF_EMAILS_VERSION', '1.1.0');
 
 require_once plugin_dir_path(__FILE__) . 'includes/class-email-manager.php';
 require_once plugin_dir_path(__FILE__) . 'templates/emails/setting-wc-email.php';
 
 function bypierofracasso_woocommerce_emails_init()
 {
-    new byPieroFracasso_Email_Manager();
+    new PFP_Email_Manager();
 }
 
 add_action('plugins_loaded', 'bypierofracasso_woocommerce_emails_init');
@@ -31,7 +31,7 @@ add_action('plugins_loaded', 'bypierofracasso_woocommerce_emails_init');
 add_action('admin_init', 'bypierofracasso_debug_plugin_active');
 function bypierofracasso_debug_plugin_active()
 {
-    error_log("byPieroFracasso WooCommerce Emails plugin (v" . BYPF_EMAILS_VERSION . ") is active on admin page load.");
+    error_log("Piero Fracasso Perfumes WooCommerce Emails plugin (v" . BYPF_EMAILS_VERSION . ") is active on admin page load.");
 }
 
 // Debug: Log order save at the WordPress level
@@ -123,7 +123,7 @@ function bypierofracasso_override_woocommerce_emails($template, $template_name, 
 add_action('plugins_loaded', 'bypierofracasso_load_textdomain');
 function bypierofracasso_load_textdomain()
 {
-    load_plugin_textdomain('bypierofracasso-woocommerce-emails', false, dirname(plugin_basename(__FILE__)) . '/languages/');
+    load_plugin_textdomain('piero-fracasso-emails', false, dirname(plugin_basename(__FILE__)) . '/languages/');
 }
 
 add_action('woocommerce_email_header', 'bypierofracasso_add_email_styles', 20);
@@ -140,36 +140,44 @@ add_filter('woocommerce_register_shop_order_post_statuses', 'bypierofracasso_reg
 function bypierofracasso_register_custom_statuses($statuses)
 {
     $statuses['wc-received'] = array(
-        'label' => _x('Received', 'Order status', 'bypierofracasso-woocommerce-emails'),
+        'label' => _x('Received', 'Order status', 'piero-fracasso-emails'),
         'public' => true,
         'exclude_from_search' => false,
         'show_in_admin_all_list' => true,
         'show_in_admin_status_list' => true,
-        'label_count' => _n_noop('Received <span class="count">(%s)</span>', 'Received <span class="count">(%s)</span>', 'bypierofracasso-woocommerce-emails'),
+        'label_count' => _n_noop('Received <span class="count">(%s)</span>', 'Received <span class="count">(%s)</span>', 'piero-fracasso-emails'),
     );
     $statuses['wc-pending-payment'] = array(
-        'label' => _x('Pending Payment', 'Order status', 'bypierofracasso-woocommerce-emails'),
+        'label' => _x('Pending Payment', 'Order status', 'piero-fracasso-emails'),
         'public' => true,
         'exclude_from_search' => false,
         'show_in_admin_all_list' => true,
         'show_in_admin_status_list' => true,
-        'label_count' => _n_noop('Pending Payment <span class="count">(%s)</span>', 'Pending Payment <span class="count">(%s)</span>', 'bypierofracasso-woocommerce-emails'),
+        'label_count' => _n_noop('Pending Payment <span class="count">(%s)</span>', 'Pending Payment <span class="count">(%s)</span>', 'piero-fracasso-emails'),
     );
     $statuses['wc-shipped'] = array(
-        'label' => _x('Shipped', 'Order status', 'bypierofracasso-woocommerce-emails'),
+        'label' => _x('Shipped', 'Order status', 'piero-fracasso-emails'),
         'public' => true,
         'exclude_from_search' => false,
         'show_in_admin_all_list' => true,
         'show_in_admin_status_list' => true,
-        'label_count' => _n_noop('Shipped <span class="count">(%s)</span>', 'Shipped <span class="count">(%s)</span>', 'bypierofracasso-woocommerce-emails'),
+        'label_count' => _n_noop('Shipped <span class="count">(%s)</span>', 'Shipped <span class="count">(%s)</span>', 'piero-fracasso-emails'),
     );
     $statuses['wc-ready-for-pickup'] = array(
-        'label' => _x('Ready for Pickup', 'Order status', 'bypierofracasso-woocommerce-emails'),
+        'label' => _x('Ready for Pickup', 'Order status', 'piero-fracasso-emails'),
         'public' => true,
         'exclude_from_search' => false,
         'show_in_admin_all_list' => true,
         'show_in_admin_status_list' => true,
-        'label_count' => _n_noop('Ready for Pickup <span class="count">(%s)</span>', 'Ready for Pickup <span class="count">(%s)</span>', 'bypierofracasso-woocommerce-emails'),
+        'label_count' => _n_noop('Ready for Pickup <span class="count">(%s)</span>', 'Ready for Pickup <span class="count">(%s)</span>', 'piero-fracasso-emails'),
+    );
+    $statuses['wc-invoice'] = array(
+        'label' => _x('Invoice', 'Order status', 'piero-fracasso-emails'),
+        'public' => true,
+        'exclude_from_search' => false,
+        'show_in_admin_all_list' => true,
+        'show_in_admin_status_list' => true,
+        'label_count' => _n_noop('Invoice <span class="count">(%s)</span>', 'Invoice <span class="count">(%s)</span>', 'piero-fracasso-emails'),
     );
     return $statuses;
 }
@@ -177,10 +185,11 @@ function bypierofracasso_register_custom_statuses($statuses)
 add_filter('wc_order_statuses', 'bypierofracasso_add_custom_order_statuses');
 function bypierofracasso_add_custom_order_statuses($order_statuses)
 {
-    $order_statuses['wc-received'] = _x('Received', 'Order status', 'bypierofracasso-woocommerce-emails');
-    $order_statuses['wc-pending-payment'] = _x('Pending Payment', 'Order status', 'bypierofracasso-woocommerce-emails');
-    $order_statuses['wc-shipped'] = _x('Shipped', 'Order status', 'bypierofracasso-woocommerce-emails');
-    $order_statuses['wc-ready-for-pickup'] = _x('Ready for Pickup', 'Order status', 'bypierofracasso-woocommerce-emails');
+    $order_statuses['wc-received'] = _x('Received', 'Order status', 'piero-fracasso-emails');
+    $order_statuses['wc-pending-payment'] = _x('Pending Payment', 'Order status', 'piero-fracasso-emails');
+    $order_statuses['wc-shipped'] = _x('Shipped', 'Order status', 'piero-fracasso-emails');
+    $order_statuses['wc-ready-for-pickup'] = _x('Ready for Pickup', 'Order status', 'piero-fracasso-emails');
+    $order_statuses['wc-invoice'] = _x('Invoice', 'Order status', 'piero-fracasso-emails');
     return $order_statuses;
 }
 
@@ -188,11 +197,26 @@ function bypierofracasso_add_custom_order_statuses($order_statuses)
 add_filter('bulk_actions-edit-shop_order', 'bypierofracasso_add_bulk_order_statuses');
 function bypierofracasso_add_bulk_order_statuses($actions)
 {
-    $actions['mark_wc-shipped'] = __('Change status to Shipped', 'bypierofracasso-woocommerce-emails');
-    $actions['mark_wc-ready-for-pickup'] = __('Change status to Ready for Pickup', 'bypierofracasso-woocommerce-emails');
+    $actions['mark_wc-shipped'] = __('Change status to Shipped', 'piero-fracasso-emails');
+    $actions['mark_wc-ready-for-pickup'] = __('Change status to Ready for Pickup', 'piero-fracasso-emails');
+    $actions['mark_wc-invoice'] = __('Change status to Invoice', 'piero-fracasso-emails');
     return $actions;
 }
 
+
+add_action('woocommerce_new_order', 'bypierofracasso_maybe_set_invoice_status', 20, 1);
+function bypierofracasso_maybe_set_invoice_status($order_id){
+    $order = wc_get_order($order_id);
+    if(!$order){
+        return;
+    }
+    $invoice_methods = apply_filters('pfp_invoice_payment_methods', array('invoice','bacs'));
+    if(in_array($order->get_payment_method(), $invoice_methods, true)){
+        if($order->has_status('on-hold') || $order->has_status('pending')){
+            $order->update_status('invoice');
+        }
+    }
+}
 // Set Initial Status to "Received" After Payment
 //add_action('woocommerce_payment_complete', 'bypierofracasso_set_initial_received_status', 10, 1);
 //function bypierofracasso_set_initial_received_status($order_id)
@@ -200,7 +224,7 @@ function bypierofracasso_add_bulk_order_statuses($actions)
 //    $order = wc_get_order($order_id);
 //    if ($order && !$order->has_status('received')) { // Remove 'wc-' prefix
 //        error_log("Setting order $order_id to received after payment");
-//        $order->update_status('wc-received', __('Order set to Received after payment.', 'bypierofracasso-woocommerce-emails')); // Keep 'wc-' for update_status
+//        $order->update_status('wc-received', __('Order set to Received after payment.', 'piero-fracasso-emails')); // Keep 'wc-' for update_status
 //        $email = WC()->mailer()->get_emails()['WC_Email_Order_Received'];
 //        if ($email && $email->is_enabled()) {
 //            $email->trigger($order_id);

--- a/includes/class-email-manager.php
+++ b/includes/class-email-manager.php
@@ -3,7 +3,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-class byPieroFracasso_Email_Manager {
+class PFP_Email_Manager {
     public function __construct() {
         add_filter('woocommerce_email_classes', array($this, 'add_custom_emails'), 999);
         add_filter('woocommerce_email_enabled_customer_payment_retry', '__return_false');

--- a/includes/class-wc-email-customer-invoice.php
+++ b/includes/class-wc-email-customer-invoice.php
@@ -39,7 +39,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
     }
 
     public function get_default_subject() {
-        return __('Your Invoice from byPieroFracasso #{order_number}', 'woocommerce');
+        return __('Your Invoice from Piero Fracasso Perfumes #{order_number}', 'woocommerce');
     }
 
     public function get_default_heading() {

--- a/includes/class-wc-email-customer-payment-failed.php
+++ b/includes/class-wc-email-customer-payment-failed.php
@@ -7,8 +7,8 @@ class WC_Email_Customer_Payment_Failed extends WC_Email {
     public function __construct() {
         $this->id = 'customer_payment_failed';
         $this->customer_email = true;
-        $this->title = __('Customer Payment Failed', 'bypierofracasso-woocommerce-emails');
-        $this->description = __('Sent to customers when payment fails for an order.', 'bypierofracasso-woocommerce-emails');
+        $this->title = __('Customer Payment Failed', 'piero-fracasso-emails');
+        $this->description = __('Sent to customers when payment fails for an order.', 'piero-fracasso-emails');
         $this->template_base = plugin_dir_path(__FILE__) . '../templates/emails/';
         $this->template_html = 'customer-payment-failed.php';
         $this->template_plain = 'plain/customer-payment-failed.php'; // Added
@@ -49,11 +49,11 @@ class WC_Email_Customer_Payment_Failed extends WC_Email {
     }
 
     public function get_default_subject() {
-        return __('Payment Failed for Order #{order_number}', 'bypierofracasso-woocommerce-emails');
+        return __('Payment Failed for Order #{order_number}', 'piero-fracasso-emails');
     }
 
     public function get_default_heading() {
-        return __('Payment Failed', 'bypierofracasso-woocommerce-emails');
+        return __('Payment Failed', 'piero-fracasso-emails');
     }
 
     public function get_content_html() {

--- a/includes/class-wc-email-order-received.php
+++ b/includes/class-wc-email-order-received.php
@@ -11,7 +11,7 @@ class WC_Email_Order_Received extends WC_Email
         $this->title = __('Bestellung erhalten', 'woocommerce');
         $this->description = __('Diese E-Mail wird gesendet, wenn eine Bestellung aufgegeben wurde.', 'woocommerce');
         $this->heading = __('Vielen Dank für deine Bestellung!', 'woocommerce');
-        $this->subject = __('Deine Bestellung bei byPieroFracasso wurde erhalten', 'woocommerce');
+        $this->subject = __('Deine Bestellung bei Piero Fracasso Perfumes wurde erhalten', 'woocommerce');
 
         $this->template_html = 'customer-order-received.php'; // Fixed path
         $this->template_plain = 'plain/customer-order-received.php'; // Fixed path

--- a/includes/class-wc-email-pending-order.php
+++ b/includes/class-wc-email-pending-order.php
@@ -11,7 +11,7 @@ class WC_Email_Pending_Order extends WC_Email
         $this->title = __('Payment pending', 'woocommerce');
         $this->description = __('This email is sent when an order is marked as “payment pending”.', 'woocommerce');
         $this->heading = __('Please transfer the amount by QR bank payment', 'woocommerce');
-        $this->subject = __('Your order with byPieroFracasso - Payment pending', 'woocommerce');
+        $this->subject = __('Your order with Piero Fracasso Perfumes - Payment pending', 'woocommerce');
 
         $this->template_html = 'customer-pending-order.php'; // Fixed path
         $this->template_plain = 'plain/customer-pending-order.php'; // Fixed path

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -141,7 +141,7 @@ do_action('woocommerce_email_header', $email_heading, $email);
                                             <td align="left" valign="middle" class="center-text font-primary font-191919 font-18 font-weight-600 font-space-0 pb-20">
                                                 <?php
                                                 if ($order instanceof WC_Order) {
-                                                    echo __($admin_new_order_greeting . ',', 'bypierofracasso-woocommerce-emails');
+                                                    echo __($admin_new_order_greeting . ',', 'piero-fracasso-emails');
                                                 } else {
                                                     echo __($admin_new_order_greeting . " Admin,");
                                                 }

--- a/templates/emails/customer-order-ready-for-pickup.php
+++ b/templates/emails/customer-order-ready-for-pickup.php
@@ -64,7 +64,7 @@ do_action('woocommerce_email_header', $email_heading, $email);
                                                     <tr>
                                                         <td align="center" class="bg-FFFFFF block btn border-radius-4">
                                                             <a href="<?php echo ($order instanceof WC_Order) ? esc_url($order->get_view_order_url()) : '#'; ?>" class="font-primary font-4B7BEC font-14 font-weight-600 font-space-0-5 block btn white-space">
-                                                                <?php echo __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); ?>
+                                                                <?php echo __('VIEW ORDER', 'piero-fracasso-emails'); ?>
                                                             </a>
                                                         </td>
                                                     </tr>
@@ -261,7 +261,7 @@ do_action('woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $
                                                     <tr>
                                                         <td align="center" class="bg-4B7BEC block btn border-radius-4">
                                                             <a href="<?php echo ($order instanceof WC_Order) ? esc_url($order->get_view_order_url()) : '#'; ?>" class="font-primary font-FFFFFF font-14 font-weight-600 font-space-0-5 block btn white-space">
-                                                                <?php echo __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); ?>
+                                                                <?php echo __('VIEW ORDER', 'piero-fracasso-emails'); ?>
                                                             </a>
                                                         </td>
                                                     </tr>

--- a/templates/emails/customer-payment-failed.php
+++ b/templates/emails/customer-payment-failed.php
@@ -37,7 +37,7 @@ do_action('woocommerce_email_header', $email_heading, $email);
                                         </tr>
                                         <tr>
                                             <td align="center" valign="middle" class="font-primary font-FFFFFF font-16 font-weight-600 pb-5 font-space-0">
-                                                <?php echo __('Payment Failed', 'bypierofracasso-woocommerce-emails'); ?>
+                                                <?php echo __('Payment Failed', 'piero-fracasso-emails'); ?>
                                             </td>
                                         </tr>
                                         <tr>
@@ -51,7 +51,7 @@ do_action('woocommerce_email_header', $email_heading, $email);
                                                     <tr>
                                                         <td align="center" class="bg-FFFFFF block btn border-radius-4">
                                                             <a href="<?php echo ($order instanceof WC_Order) ? esc_url($order->get_checkout_payment_url()) : '#'; ?>" class="font-primary font-4B7BEC font-14 font-weight-600 font-space-0-5 block btn white-space">
-                                                                <?php echo __('TRY AGAIN', 'bypierofracasso-woocommerce-emails'); ?>
+                                                                <?php echo __('TRY AGAIN', 'piero-fracasso-emails'); ?>
                                                             </a>
                                                         </td>
                                                     </tr>
@@ -129,9 +129,9 @@ do_action('woocommerce_email_header', $email_heading, $email);
                                             <td align="left" valign="middle" class="center-text font-primary font-191919 font-18 font-weight-600 font-space-0 pb-20">
                                                 <?php
                                                 if ($order instanceof WC_Order) {
-                                                    echo __('Hello ' . esc_html($order->get_billing_first_name()) . ',', 'bypierofracasso-woocommerce-emails');
+                                                    echo __('Hello ' . esc_html($order->get_billing_first_name()) . ',', 'piero-fracasso-emails');
                                                 } else {
-                                                    echo __('Hello Customer,', 'bypierofracasso-woocommerce-emails');
+                                                    echo __('Hello Customer,', 'piero-fracasso-emails');
                                                 }
                                                 ?>
                                             </td>
@@ -139,7 +139,7 @@ do_action('woocommerce_email_header', $email_heading, $email);
                                         <tr>
                                             <td align="left" valign="middle" class="center-text font-primary font-595959 font-16 font-weight-400 font-space-0 pb-20" style="padding:0px;">
                                                 <?php
-                                                echo __('Unfortunately, we couldn\'t complete your order due to an issue with your payment method.', 'bypierofracasso-woocommerce-emails');
+                                                echo __('Unfortunately, we couldn\'t complete your order due to an issue with your payment method.', 'piero-fracasso-emails');
                                                 if ($additional_content) {
                                                     echo '<br><br>' . wp_kses_post(wptexturize($additional_content));
                                                 }
@@ -150,7 +150,7 @@ do_action('woocommerce_email_header', $email_heading, $email);
                                                 ?>
                                                 <br><br>
                                                 <a href="<?php echo ($order instanceof WC_Order) ? esc_url($order->get_checkout_payment_url()) : '#'; ?>" class="font-4B7BEC">
-                                                    <?php echo __('Try a different payment method', 'bypierofracasso-woocommerce-emails'); ?>
+                                                    <?php echo __('Try a different payment method', 'piero-fracasso-emails'); ?>
                                                 </a>
                                             </td>
                                         </tr>
@@ -237,7 +237,7 @@ do_action('woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $
                                                     <tr>
                                                         <td align="center" class="bg-4B7BEC block btn border-radius-4">
                                                             <a href="<?php echo ($order instanceof WC_Order) ? esc_url($order->get_checkout_payment_url()) : '#'; ?>" class="font-primary font-FFFFFF font-14 font-weight-600 font-space-0-5 block btn white-space">
-                                                                <?php echo __('TRY AGAIN', 'bypierofracasso-woocommerce-emails'); ?>
+                                                                <?php echo __('TRY AGAIN', 'piero-fracasso-emails'); ?>
                                                             </a>
                                                         </td>
                                                     </tr>

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -106,7 +106,7 @@ foreach ($items as $item_id => $item) :
                                                     <tr>
                                                         <td align="left" valign="middle" class="center-text font-primary font-595959 font-16 font-weight-400 font-space-0 small capitalize">
                                                             <?php
-                                                                echo apply_filters('woocommerce_email_order_item_quantity', ' Qty: ' . $item->get_quantity(), $item) . ' , Price: ';
+                                                                echo apply_filters('woocommerce_email_order_item_quantity', 'Qty: ' . $item->get_quantity(), $item) . ', Price: ';
                                                                 if (is_a($product, 'WC_Product') && $product->exists()) {
                                                                     if ($product->get_sale_price() != '') {
                                                                         echo wc_price($product->get_sale_price());
@@ -139,7 +139,7 @@ foreach ($items as $item_id => $item) :
                                                     </tr>
 
                                                     <tr>
-                                                        <td align="right" valign="middle" class="center-text font-primary font-191919 font-20 font-weight-600 font-space-0 small">
+                                                        <td align="right" valign="middle" class="center-text font-primary font-191919 font-20 font-weight-600 font-space-0 small white-space">
                                                             <?php echo $order->get_formatted_line_subtotal($item); ?>
                                                         </td>
                                                     </tr>

--- a/templates/emails/setting-wc-email.php
+++ b/templates/emails/setting-wc-email.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Email Styles for byPieroFracasso WooCommerce Emails
+ * Email Styles for Piero Fracasso Perfumes WooCommerce Emails
  *
- * This file is part of the byPieroFracasso WooCommerce Email Plugin.
+ * This file is part of the Piero Fracasso Perfumes WooCommerce Email Plugin.
  * It defines the styles and custom settings for all email templates used in this plugin.
  *
- * @package  byPieroFracasso - WooCommerce Email Templates
- * @author   byPieroFracasso
+ * @package  Piero Fracasso Perfumes - WooCommerce Email Templates
+ * @author   Piero Fracasso Perfumes
  * @version  1.0.0
  */
 
@@ -17,145 +17,145 @@ if (!defined('ABSPATH')) {
 // ********************************************************//
 //            Customer Order Completed
 // ********************************************************//
-$completed_order_subtitle      = __('Your order is complete!', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
-$completed_order_btn           = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$completed_order_subtitle      = __('Your order is complete!', 'piero-fracasso-emails'); // Header SubTitle
+$completed_order_btn           = __('VIEW ORDER', 'piero-fracasso-emails'); // Button
 $completed_order_hero_bg_img   = 'email-header-cust-completed.png'; // Header Image File Name
-$completed_order_greeting      = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
-$completed_order_message       = __('Your order at byPieroFracasso is now complete! If you haven’t received it yet, it will be with you shortly. We hope you love your new fragrance! If you have any questions, feel free to reach out.', 'bypierofracasso-woocommerce-emails'); // Custom message
+$completed_order_greeting      = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
+$completed_order_message       = __('Your order at Piero Fracasso Perfumes is now complete! If you haven’t received it yet, it will be with you shortly. We hope you love your new fragrance! If you have any questions, feel free to reach out.', 'piero-fracasso-emails'); // Custom message
 
 // ***************************************************//
 //      Customer Order Received
 // ***************************************************//
-$order_received_subtitle       = __('We have received your order!', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
+$order_received_subtitle       = __('We have received your order!', 'piero-fracasso-emails'); // Header SubTitle
 $order_received_hero_bg_img    = 'email-header-cust-order-received.png'; // Header Image File Name
-$order_received_greeting       = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$order_received_greeting       = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 $order_received_message        = __('Thank you for your order! We’ve received it successfully and will review it shortly. You’ll receive an update once your order is being processed.', 'woocommerce');
-$order_received_btn            = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$order_received_btn            = __('VIEW ORDER', 'piero-fracasso-emails'); // Button
 
 // ***************************************************//
 //      Customer Order Payment Pending
 // ***************************************************//
-$pending_order_subtitle        = __('Your payment is pending', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
+$pending_order_subtitle        = __('Your payment is pending', 'piero-fracasso-emails'); // Header SubTitle
 $pending_order_hero_bg_img     = 'email-header-cust-pending-payment.png'; // Header Image File Name
-$pending_order_greeting        = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
-$pending_order_btn             = __('PAY NOW', 'bypierofracasso-woocommerce-emails'); // Button
+$pending_order_greeting        = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
+$pending_order_btn             = __('PAY NOW', 'piero-fracasso-emails'); // Button
 
 // ***************************************************//
 //      Customer Order Shipped
 // ***************************************************//
-$shipped_order_subtitle        = __('Your order is on its way!', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
+$shipped_order_subtitle        = __('Your order is on its way!', 'piero-fracasso-emails'); // Header SubTitle
 $shipped_order_hero_bg_img     = 'email-header-cust-shipped.png'; // Header Image File Name
-$shipped_order_greeting        = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$shipped_order_greeting        = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 $shipped_order_message         = __('Good news! Your order is on its way and will reach you shortly. Thank you for choosing us!'); // Email text
-//$shipped_order_btn             = __('TRACK ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+//$shipped_order_btn             = __('TRACK ORDER', 'piero-fracasso-emails'); // Button
 
 // ***************************************************//
 //      Customer Order Ready for Pickup
 // ***************************************************//
-$pickup_order_subtitle        = __('Your order is ready for pickup!', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
+$pickup_order_subtitle        = __('Your order is ready for pickup!', 'piero-fracasso-emails'); // Header SubTitle
 $pickup_order_hero_bg_img     = 'email-header-cust-shipped.png'; // Header Image File Name
-$pickup_order_greeting        = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$pickup_order_greeting        = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 $pickup_order_message         = __('e are pleased to inform you that your order is now ready for pickup! The pickup location is provided below. Thank you for shopping with us — we look forward to seeing you soon!'); // Email text
 
 // ********************************************************//
 //            Customer Invoice
 // ********************************************************//
-$invoice_subtitle              = __('Your Invoice for Your Order at byPieroFracasso', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
+$invoice_subtitle              = __('Your Invoice for Your Order at Piero Fracasso Perfumes', 'piero-fracasso-emails'); // Header SubTitle
 $invoice_hero_bg_img           = 'email-header-cust-invoice.png'; // Header Image File Name
-$invoice_greeting              = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
-$invoice_pending_btn           = __('PAY NOW', 'bypierofracasso-woocommerce-emails'); // Invoice Pending Button Text
-$invoice_complete_btn          = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Invoice Order Complete Button Text
+$invoice_greeting              = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
+$invoice_pending_btn           = __('PAY NOW', 'piero-fracasso-emails'); // Invoice Pending Button Text
+$invoice_complete_btn          = __('VIEW ORDER', 'piero-fracasso-emails'); // Invoice Order Complete Button Text
 
 // ***********************************************//
 //            Customer New Account
 // ***********************************************//
-$new_account_subtitle          = __('Before we get started', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
+$new_account_subtitle          = __('Before we get started', 'piero-fracasso-emails'); // Header SubTitle
 $new_account_hero_bg_img       = 'email-header-cust-new-account.png'; // Header Image File Name
-$new_account_btn               = __('VERIFY EMAIL', 'bypierofracasso-woocommerce-emails'); // Button
-$new_account_greeting          = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
-$new_account_link_text         = __('Or you can confirm email using this Link :', 'bypierofracasso-woocommerce-emails'); // Reset Password Description
-$new_account_link              = __('Click here to reset your password', 'bypierofracasso-woocommerce-emails'); // Reset Password Link
+$new_account_btn               = __('VERIFY EMAIL', 'piero-fracasso-emails'); // Button
+$new_account_greeting          = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
+$new_account_link_text         = __('Or you can confirm email using this Link:', 'piero-fracasso-emails'); // Reset Password Description
+$new_account_link              = __('Click here to reset your password', 'piero-fracasso-emails'); // Reset Password Link
 $new_account_regards_show      = "NO"; // Team Regards Show 'YES' or 'NO', Case Sensitive
-$new_account_regards_1         = __('Thank You,', 'bypierofracasso-woocommerce-emails'); // Regards Thank You Text
-$new_account_regards_2         = __('byPieroFracasso', 'bypierofracasso-woocommerce-emails'); // Regards Team Text
-$new_account_description       = __('If you didn\'t request to change your password, You don\'t have to do anything.', 'bypierofracasso-woocommerce-emails'); // Reset Password Description
+$new_account_regards_1         = __('Thank You,', 'piero-fracasso-emails'); // Regards Thank You Text
+$new_account_regards_2         = __('Piero Fracasso Perfumes', 'piero-fracasso-emails'); // Regards Team Text
+$new_account_description       = __('If you didn\'t request to change your password, You don\'t have to do anything.', 'piero-fracasso-emails'); // Reset Password Description
 
 // ********************************************************//
 //            Customer Note
 // ********************************************************//
-$customer_note_subtitle        = __('A note has been added', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
-$customer_note_btn             = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$customer_note_subtitle        = __('A note has been added', 'piero-fracasso-emails'); // Header SubTitle
+$customer_note_btn             = __('VIEW ORDER', 'piero-fracasso-emails'); // Button
 $customer_note_hero_bg_img     = 'email-header-cust-note.png'; // Header Image File Name
-$customer_note_greeting        = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$customer_note_greeting        = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 
 // ********************************************************//
 //            Customer on-Hold Order
 // ********************************************************//
-$on_hold_order_subtitle        = __('Until payment is received', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
-$on_hold_order_btn             = __('MANAGE ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$on_hold_order_subtitle        = __('Until payment is received', 'piero-fracasso-emails'); // Header SubTitle
+$on_hold_order_btn             = __('MANAGE ORDER', 'piero-fracasso-emails'); // Button
 $on_hold_order_hero_bg_img     = 'email-header-cust-on-hold.png'; // Header Image File Name
-$on_hold_order_greeting        = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$on_hold_order_greeting        = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 
 // ********************************************************//
 //            Customer Processing Order
 // ********************************************************//
-$processing_order_subtitle     = __('Your order is currently being processed. We will notify you as soon as it has been shipped.', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
-$processing_order_btn          = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$processing_order_subtitle     = __('Your order is currently being processed. We will notify you as soon as it has been shipped.', 'piero-fracasso-emails'); // Header SubTitle
+$processing_order_btn          = __('VIEW ORDER', 'piero-fracasso-emails'); // Button
 $processing_order_hero_bg_img  = 'email-header-cust-processing.png'; // Header Image File Name
-$processing_order_greeting     = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$processing_order_greeting     = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 
 // ***********************************************//
 //            Customer Refunded Order
 // ***********************************************//
-$refunded_order_subtitle       = __('Your order refund status', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
-$refunded_order_btn            = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$refunded_order_subtitle       = __('Your order refund status', 'piero-fracasso-emails'); // Header SubTitle
+$refunded_order_btn            = __('VIEW ORDER', 'piero-fracasso-emails'); // Button
 $refunded_order_hero_bg_img    = 'email-header-cust-refund.png'; // Header Icon Image File Name
-$refunded_order_greeting       = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$refunded_order_greeting       = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 
 // ***********************************************//
 //            Customer Reset Password
 // ***********************************************//
-$reset_password_subtitle       = __('We got a request to', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
+$reset_password_subtitle       = __('We got a request to', 'piero-fracasso-emails'); // Header SubTitle
 $reset_password_hero_bg_img    = 'email-header-cust-reset-pw.png'; // Header Icon Image File Name
-$reset_password_btn            = __('RESET PASSWORD', 'bypierofracasso-woocommerce-emails'); // Button
-$reset_password_greeting       = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
-$reset_password_link_text      = __('Or you can set password using this Link:', 'bypierofracasso-woocommerce-emails'); // Reset Password Description
-$reset_password_link           = __('Click here to reset your password', 'bypierofracasso-woocommerce-emails'); // Reset Password Link
+$reset_password_btn            = __('RESET PASSWORD', 'piero-fracasso-emails'); // Button
+$reset_password_greeting       = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
+$reset_password_link_text      = __('Or you can set password using this Link:', 'piero-fracasso-emails'); // Reset Password Description
+$reset_password_link           = __('Click here to reset your password', 'piero-fracasso-emails'); // Reset Password Link
 $reset_password_regards_show   = "NO"; // Team Regards Show 'YES' or 'NO', Case Sensitive
-$reset_password_regards_1      = __('Thank You,', 'bypierofracasso-woocommerce-emails'); // Regards Thank You Text
-$reset_password_regards_2      = __('Team Starto', 'bypierofracasso-woocommerce-emails'); // Regards Team Text
-$reset_password_description    = __('If you didn\'t request to change your Starto password, You don\'t have to do anything. So that\'s easy', 'bypierofracasso-woocommerce-emails'); // Reset Password Description
+$reset_password_regards_1      = __('Thank You,', 'piero-fracasso-emails'); // Regards Thank You Text
+$reset_password_regards_2      = __('Team Starto', 'piero-fracasso-emails'); // Regards Team Text
+$reset_password_description    = __('If you didn\'t request to change your Starto password, You don\'t have to do anything. So that\'s easy', 'piero-fracasso-emails'); // Reset Password Description
 
 // ******************************************************//
 //            Admin Cancelled Order
 // ******************************************************//
-$admin_cancelled_order_subtitle = __('Order has been canceled!', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
-$admin_cancelled_order_btn      = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$admin_cancelled_order_subtitle = __('Order has been canceled!', 'piero-fracasso-emails'); // Header SubTitle
+$admin_cancelled_order_btn      = __('VIEW ORDER', 'piero-fracasso-emails'); // Button
 $admin_cancelled_order_hero_bg_img = 'email-header-admin-cancelled.png'; // Header Image File Name
-$admin_cancelled_order_greeting = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$admin_cancelled_order_greeting = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 
 // ******************************************************//
 //            Admin Failed Order
 // ******************************************************//
-$admin_failed_order_subtitle    = __('A customer order has failed. Immediate action may be required.', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
-$admin_failed_order_btn         = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$admin_failed_order_subtitle    = __('A customer order has failed. Immediate action may be required.', 'piero-fracasso-emails'); // Header SubTitle
+$admin_failed_order_btn         = __('VIEW ORDER', 'piero-fracasso-emails'); // Button
 $admin_failed_order_hero_bg_img = 'email-header-admin-failed.png'; // Header Image File Name
-$admin_failed_order_greeting    = __('Hello', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$admin_failed_order_greeting    = __('Hello', 'piero-fracasso-emails'); // Greeting Before User First Name
 
 // ***********************************************//
 //            Admin New Order
 // ***********************************************//
-$admin_new_order_subtitle       = __('A new customer order has been placed.', 'bypierofracasso-woocommerce-emails'); // Header SubTitle
-$admin_new_order_btn            = __('VIEW ORDER', 'bypierofracasso-woocommerce-emails'); // Button
+$admin_new_order_subtitle       = __('A new customer order has been placed.', 'piero-fracasso-emails'); // Header SubTitle
+$admin_new_order_btn            = __('VIEW ORDER', 'piero-fracasso-emails'); // Button
 $admin_new_order_hero_bg_img    = 'email-header-admin-new-order.png'; // Header Image File Name
-$admin_new_order_greeting       = __('Hello Piero & Mario', 'bypierofracasso-woocommerce-emails'); // Greeting Before User First Name
+$admin_new_order_greeting       = __('Hello Piero & Mario', 'piero-fracasso-emails'); // Greeting Before User First Name
 $admin_new_order_message        = __('Someone just bought a product. Please review it and change its status promptly.'); // Email text
 
 // ***********************************************//
 //            Top Offer Customization
 // ***********************************************//
 $top_offer_show                = 'NO'; // Top Msg Show 'YES' or 'NO', Case Sensitive
-$top_offer_text                = __('Starto 30% OFF →', 'bypierofracasso-woocommerce-emails');
+$top_offer_text                = __('Starto 30% OFF →', 'piero-fracasso-emails');
 $top_offer_link                = 'http://example.com/'; // URL
 
 // ***********************************************//
@@ -168,28 +168,28 @@ $logoWidth                     = '130'; // Logo Width in Pixels – add only the
 // ***********************************************//
 $menu_link_show                = "NO"; // Menu Links Show 'YES' or 'NO', Case Sensitive
 $menu_divider_color            = '#81A6FF'; // Menu Divider Color
-$menu_link_text_1              = __('Home', 'bypierofracasso-woocommerce-emails');
+$menu_link_text_1              = __('Home', 'piero-fracasso-emails');
 $menu_link_1                   = 'http://example.com/';
-$menu_link_text_2              = __('About', 'bypierofracasso-woocommerce-emails');
+$menu_link_text_2              = __('About', 'piero-fracasso-emails');
 $menu_link_2                   = 'http://example.com/';
-$menu_link_text_3              = __('Blog', 'bypierofracasso-woocommerce-emails');
+$menu_link_text_3              = __('Blog', 'piero-fracasso-emails');
 $menu_link_3                   = 'http://example.com/';
-$menu_link_text_4              = __('Sale', 'bypierofracasso-woocommerce-emails');
+$menu_link_text_4              = __('Sale', 'piero-fracasso-emails');
 $menu_link_4                   = 'http://example.com/';
 
 // ***********************************************//
 //            Other Product Customization
 // ***********************************************//
 $other_product_show            = 'YES'; // Other product Show 'YES' or 'NO', Case Sensitive
-$other_product_title           = __('Your Fragrance Journey Starts Here', 'bypierofracasso-woocommerce-emails');
+$other_product_title           = __('Your Fragrance Journey Starts Here', 'piero-fracasso-emails');
 $other_product_1_img           = 'transaction@other-product-1.png'; // Image file name
 $other_product_1_link          = 'https://bypierofracasso.com/product/samples/';
-$other_product_1_title         = __('Try Our Samples', 'bypierofracasso-woocommerce-emails');
-$other_product_1_price         = __('Six for CHF 18.00', 'bypierofracasso-woocommerce-emails');
+$other_product_1_title         = __('Try Our Samples', 'piero-fracasso-emails');
+$other_product_1_price         = __('Six for CHF 18.00', 'piero-fracasso-emails');
 $other_product_2_img           = 'transaction@other-product-2.png';
 $other_product_2_link          = 'https://bypierofracasso.com/product/gift-card/';
-$other_product_2_title         = __('Our Gift Cards', 'bypierofracasso-woocommerce-emails');
-$other_product_2_price         = __('CHF 90.00 - CHF 280.00', 'bypierofracasso-woocommerce-emails');
+$other_product_2_title         = __('Our Gift Cards', 'piero-fracasso-emails');
+$other_product_2_price         = __('CHF 90.00 - CHF 280.00', 'piero-fracasso-emails');
 
 // ***********************************************//
 //            Banner Customization
@@ -202,7 +202,7 @@ $banner_link                   = 'http://example.com'; // Banner Link
 //            Footer App Customization
 // ***********************************************//
 $download_app_show             = "NO"; // Footer App Button Show 'YES' or 'NO', Case Sensitive
-$footer_app_title              = __('Download Our App', 'bypierofracasso-woocommerce-emails');
+$footer_app_title              = __('Download Our App', 'piero-fracasso-emails');
 $footer_app_1_img              = 'app-dark-ios-store.png'; // Image file name
 $footer_app_1_link             = 'http://example.com';
 $footer_app_2_img              = 'app-dark-android-store.png'; // Image file name
@@ -211,12 +211,12 @@ $footer_app_2_link             = 'http://example.com';
 // ***********************************************//
 //            Footer Info Customization
 // ***********************************************//
-$footer_info                   = __("If you have any questions or problems with your delivery, please visit our <br><a href='https://bypierofracasso.com/support'>Support Page</a>.<br> © byPieroFracasso | All rights reserved.", 'bypierofracasso-woocommerce-emails');
+$footer_info                   = __("If you have any questions or problems with your delivery, please visit our <br><a href='https://bypierofracasso.com/support'>Support Page</a>.<br> © Piero Fracasso Perfumes | All rights reserved.", 'piero-fracasso-emails');
 
 // ***********************************************//
 //            Footer Social Icon Customization
 // ***********************************************//
-$footer_social_title           = __('Follow Us', 'bypierofracasso-woocommerce-emails');
+$footer_social_title           = __('Follow Us', 'piero-fracasso-emails');
 $social_1_img                  = 'social-icon-facebook.png';
 $social_1_link                 = 'https://www.facebook.com/people/Bypierofracasso-Perfumes/61572907035801/';
 $social_2_img                  = 'social-icon-twitter.png';
@@ -231,11 +231,11 @@ $social_5_link                 = '';
 // ***********************************************//
 //            Footer Links Customization
 // ***********************************************//
-$footer_link_name_1            = __('FAQ', 'bypierofracasso-woocommerce-emails');
+$footer_link_name_1            = __('FAQ', 'piero-fracasso-emails');
 $footer_link_1                 = 'https://bypierofracasso.com/faq/';
-$footer_link_name_2            = __('TERMS & CONDITIONS', 'bypierofracasso-woocommerce-emails');
+$footer_link_name_2            = __('TERMS & CONDITIONS', 'piero-fracasso-emails');
 $footer_link_2                 = 'https://bypierofracasso.com/terms-conditions/';
-$footer_link_name_3            = __('SUPPORT', 'bypierofracasso-woocommerce-emails');
+$footer_link_name_3            = __('SUPPORT', 'piero-fracasso-emails');
 $footer_link_3                 = 'https://bypierofracasso.com/support/';
-$footer_link_name_4            = __('CONTACT', 'bypierofracasso-woocommerce-emails');
+$footer_link_name_4            = __('CONTACT', 'piero-fracasso-emails');
 $footer_link_4                 = 'https://bypierofracasso.com/contact-us/';


### PR DESCRIPTION
## Summary
- rebrand plugin strings to "Piero Fracasso Perfumes" and switch text domain to `piero-fracasso-emails`
- introduce custom `invoice` order status with bulk action and automatic assignment for invoice payment methods
- keep email item prices on one line and clean up label colons
- bump plugin version to 1.1.0

## Testing
- `php -l bypierofracasso-woocommerce-emails.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf238437548323a52a6329f680f746