### PR TITLE
Add dependency guards and JimSoft conflict detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Piero Fracasso Perfumes WooCommerce Emails plugin will be documented in this file.
 
+## [1.1.1] - 2025-09-08
+### Fixed
+- Added guard checks to prevent fatal errors when WooCommerce or dependencies are missing.
+- Plugin initialization now waits until `plugins_loaded` priority 11 and verifies WooCommerce availability.
+- Avoids duplicate QR invoice functionality by detecting active JimSoft plugins and showing an admin warning.
+- Composer autoloader is loaded only when present, otherwise an admin notice is displayed.
+
 ## [1.1.0] - 2025-09-08
 ### Added
   - Introduced custom `invoice` order status with bulk action support and automatic assignment for configured payment methods.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
     define('WP_DEBUG', true);
     define('WP_DEBUG_LOG', true);
     define('WP_DEBUG_DISPLAY', false);
+    ```
+    This keeps logs in `wp-content/debug.log` without exposing errors to visitors.
+
+### JimSoft Migration
+The plugin replaces the legacy *JimSoft QR-Invoice* extension. If that plugin is active, a warning is shown and QR features are disabled to avoid conflicts. Please deactivate JimSoft before using this plugin.
+
+### Deployment
+WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.1.1`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
+
+### Error Handling
+If required QR invoice settings (e.g. CHF currency or QR-IBAN) are missing, PDF attachments are skipped gracefully and a log entry is written – no fatal errors occur.


### PR DESCRIPTION
## Summary
- Load Composer autoloader conditionally and warn when missing
- Delay initialization until WooCommerce is available and skip when JimSoft plugin is active
- Document deployment steps and conflict handling

## Testing
- `composer install` *(fails: Composer could not find a composer.json file)*
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68bf2928bf148323b70f06645db799de