### PR TITLE
Defer WooCommerce email plugin init and add logger fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Piero Fracasso Perfumes WooCommerce Emails plugin will be documented in this file.
 
+## [1.1.3] - 2025-09-10
+### Fixed
+- Fix: Prevent fatal when `wc_get_logger()` is unavailable by delaying plugin bootstrap until WooCommerce loads and providing a logger fallback.
+
 ## [1.1.2] - 2025-09-09
 ### Fixed
 - Fix: Plugin-Checker Compliance (escaping/i18n/nonce/logging).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Piero Fracasso Perfumes WooCommerce Emails
 
+**Stable tag:** 1.1.3
+
 ## Overview
 The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress plugin designed to enhance the email functionality of WooCommerce for the Piero Fracasso Perfumes online store. It introduces custom order statuses, corresponding email notifications, and overrides default WooCommerce email templates with branded versions. The plugin also disables unnecessary default WooCommerce emails to streamline notifications.
 
@@ -46,7 +48,7 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
 The plugin replaces the legacy *JimSoft QR-Invoice* extension. If that plugin is active, a warning is shown and QR features are disabled to avoid conflicts. Please deactivate JimSoft before using this plugin.
 
 ### Deployment
-WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.1.2`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
+WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.1.3`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
 
 ### Error Handling
 If required QR invoice settings (e.g. CHF currency or QR-IBAN) are missing, PDF attachments are skipped gracefully and a log entry is written – no fatal errors occur.


### PR DESCRIPTION
## Summary
- defer plugin bootstrap until WooCommerce loads with guards and autoloader checks
- add robust logger fallback and early activation/runtime WooCommerce checks
- bump version to 1.1.3 and update changelog/readme

## Testing
- `php -l bypierofracasso-woocommerce-emails.php`
- `git ls-files '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68bf30ad514083238d0802d7d5a9be39