### PR TITLE
Improve Swiss QR gateway visibility with configurable icon and admin diagnostics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,14 @@
 /docker export-ignore
 /.idea export-ignore
 /.vscode export-ignore
+*.md export-ignore
+README.md !export-ignore
+CHANGELOG.md !export-ignore
+*.psd export-ignore
+*.zip export-ignore
+*.map export-ignore
+Thumbs.db export-ignore
+*.lock export-ignore
+*.dist export-ignore
 *.DS_Store export-ignore
+*.gitkeep export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.2.2] - 2025-09-13
+### Added
+- Binärfreie Icon-Integration (Inline-SVG + Icon-URL Setting).
+### Chore
+- Packaging-Regeln für Releases.
+
+## [1.2.1] - 2025-09-13
+### Fixed
+- Gateway sichtbar im Checkout – korrigierte `is_available()`-Logik, Admin-Diagnose, Test-Force-Visible.
+### Added
+- Gateway-Icon (`assets/img/qr-gateway-icon.png`).
+### Chore
+- Keine JimSoft-Assets (`swiss-qr-bill`/`tcpdf_min`); Composer-Vendor bleibt Quelle der Wahrheit.
+
 ## [1.2.0] - 2025-09-13
 ### Added
 - Feature: New payment gateway 'Rechnung (Swiss QR)', sets order status invoice, auto-attaches QR invoice PDF; WPML-ready; JimSoft replacement.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Piero Fracasso Perfumes WooCommerce Emails
 
-**Stable tag:** 1.2.0
+**Stable tag:** 1.2.2
 
 ## Overview
 The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress plugin designed to enhance the email functionality of WooCommerce for the Piero Fracasso Perfumes online store. It introduces custom order statuses, corresponding email notifications, and overrides default WooCommerce email templates with branded versions. The plugin also disables unnecessary default WooCommerce emails to streamline notifications.
@@ -22,6 +22,8 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
   - Includes plain text versions in `templates/emails/plain/`.
 - **Disable Default Emails**:
 - **Payment Gateway:** Provides a 'Rechnung (Swiss QR)' option that sets the order status to invoice and attaches a QR invoice PDF.
+  - Displays a neutral inline SVG icon by default; you may set a custom icon URL or upload `assets/img/qr-gateway-icon.png` via SFTP (setting takes priority).
+  - Admins can enable checkout diagnostics and force visibility for testing via filter `pfp_invoice_force_visible`.
   - Disables unnecessary WooCommerce emails like payment retry, renewal invoices, and certain failed order emails to reduce notification clutter.
 - **Debugging Support**:
   - Extensive debug logging to track email triggers, status changes, and plugin activity.
@@ -47,10 +49,10 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
     This keeps logs in `wp-content/debug.log` without exposing errors to visitors.
 
 ### JimSoft Migration
-The plugin replaces the legacy *JimSoft QR-Invoice* extension. If that plugin is active, a warning is shown and QR features are disabled to avoid conflicts. Please deactivate JimSoft before using this plugin.
+The plugin replaces the legacy *JimSoft QR-Invoice* extension. If that plugin is active, a warning is shown; please deactivate JimSoft to avoid conflicts.
 
 ### Deployment
-WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.0`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
+WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.2`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
 
 The released ZIP now includes the `vendor/` directory, so no Composer installation is required on production systems.
 

--- a/bypierofracasso-woocommerce-emails.php
+++ b/bypierofracasso-woocommerce-emails.php
@@ -4,7 +4,7 @@ Plugin Name: Piero Fracasso Perfumes WooCommerce Emails
 Plugin URI: https://bypierofracasso.com/
 Description: Steuert alle WooCommerce-E-Mails und deaktiviert nicht benötigte Standardmails.
 
-Version: 1.2.0
+Version: 1.2.2
 
 Author: Piero Fracasso Perfumes
 Author URI: https://bypierofracasso.com/
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('BYPF_EMAILS_VERSION', '1.2.0');
+define('BYPF_EMAILS_VERSION', '1.2.2');
 
 function bypf_log($message, $level = 'debug')
 {
@@ -441,14 +441,13 @@ function bypierofracasso_woocommerce_emails_bootstrap()
     require_once plugin_dir_path(__FILE__) . 'templates/emails/setting-wc-email.php';
 
     if (bypf_is_jimsoft_active()) {
-        bypf_log('Piero Fracasso Emails: JimSoft extension detected; plugin initialization skipped.', 'warning');
+        bypf_log('Piero Fracasso Emails: JimSoft extension detected; please deactivate it.', 'warning');
         add_action('admin_notices', function () {
             echo '<div class="notice notice-warning"><p>' . esc_html__(
                 'JimSoft QR invoice plugin is active. Please deactivate it; functionality is now provided by Piero Fracasso Perfumes WooCommerce Emails.',
                 'piero-fracasso-emails'
             ) . '</p></div>';
         });
-        return;
     }
 
     require_once plugin_dir_path(__FILE__) . 'includes/class-pfp-gateway-invoice.php';


### PR DESCRIPTION
## Summary
- Allow custom payment icon via new `Icon-URL` setting with inline SVG default and optional `assets/img/` fallback
- Tighten packaging via `.gitattributes` to exclude development files from release exports
- Bump plugin to 1.2.2 and document binary-free icon handling

## Testing
- `php -l includes/class-pfp-gateway-invoice.php`
- `php -l bypierofracasso-woocommerce-emails.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfe6a9f764832394f10e54d7558b05