### PR TITLE
Add Swiss QR gateway icon with SVG fallback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,4 @@ Thumbs.db export-ignore
 *.dist export-ignore
 *.DS_Store export-ignore
 *.gitkeep export-ignore
+assets/img/.gitkeep !export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.3] - 2025-09-13
+### Added
+- Feature: Gateway-Icon vorbereitet (PNG im Plugin unter assets/img/qr-gateway-icon.png), Fallback auf Inline-SVG, keine Binärdateien im PR.
+
 ## [1.2.2] - 2025-09-13
 ### Added
 - Binärfreie Icon-Integration (Inline-SVG + Icon-URL Setting).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Piero Fracasso Perfumes WooCommerce Emails
 
-**Stable tag:** 1.2.2
+**Stable tag:** 1.2.3
 
 ## Overview
 The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress plugin designed to enhance the email functionality of WooCommerce for the Piero Fracasso Perfumes online store. It introduces custom order statuses, corresponding email notifications, and overrides default WooCommerce email templates with branded versions. The plugin also disables unnecessary default WooCommerce emails to streamline notifications.
@@ -52,7 +52,7 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
 The plugin replaces the legacy *JimSoft QR-Invoice* extension. If that plugin is active, a warning is shown; please deactivate JimSoft to avoid conflicts.
 
 ### Deployment
-WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.2`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
+WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.3`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
 
 The released ZIP now includes the `vendor/` directory, so no Composer installation is required on production systems.
 

--- a/bypierofracasso-woocommerce-emails.php
+++ b/bypierofracasso-woocommerce-emails.php
@@ -4,7 +4,7 @@ Plugin Name: Piero Fracasso Perfumes WooCommerce Emails
 Plugin URI: https://bypierofracasso.com/
 Description: Steuert alle WooCommerce-E-Mails und deaktiviert nicht benötigte Standardmails.
 
-Version: 1.2.2
+Version: 1.2.3
 
 Author: Piero Fracasso Perfumes
 Author URI: https://bypierofracasso.com/
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('BYPF_EMAILS_VERSION', '1.2.2');
+define('BYPF_EMAILS_VERSION', '1.2.3');
 
 function bypf_log($message, $level = 'debug')
 {

--- a/includes/class-pfp-gateway-invoice.php
+++ b/includes/class-pfp-gateway-invoice.php
@@ -59,15 +59,13 @@ class PFP_Gateway_Invoice extends WC_Payment_Gateway
             'description' => array(
                 'title'       => __('Description', 'piero-fracasso-emails'),
                 'type'        => 'textarea',
-                'description' => __('Checkout description shown to the customer.', 'piero-fracasso-emails'),
-                'default'     => __('Sie erhalten eine Rechnung mit Swiss-QR-Code im Anhang der Bestellbestätigung.', 'piero-fracasso-emails'),
-            ),
-            'icon_url' => array(
-                'title'       => __('Icon-URL (optional)', 'piero-fracasso-emails'),
-                'type'        => 'url',
-                'description' => __('Sie können ein Icon aus der Medienbibliothek verwenden (URL einfügen). Wenn leer, wird ein neutrales Inline-SVG angezeigt.', 'piero-fracasso-emails'),
-                'default'     => '',
-                'desc_tip'    => true,
+            'description' => __('Checkout description shown to the customer.', 'piero-fracasso-emails'),
+            'default'     => __('Sie erhalten eine Rechnung mit Swiss-QR-Code im Anhang der Bestellbestätigung.', 'piero-fracasso-emails'),
+        ),
+            'icon_info' => array(
+                'title'       => __('Icon', 'piero-fracasso-emails'),
+                'type'        => 'title',
+                'description' => __('Standard-Icon wird als Inline-SVG angezeigt. Für ein eigenes Icon legen Sie bitte eine Datei unter assets/img/qr-gateway-icon.png ab. (PNG, transparente Kanten, ~32 px Höhe empfohlen.)', 'piero-fracasso-emails'),
             ),
             'only_ch_li' => array(
                 'title'   => __('Restrict to CH/LI', 'piero-fracasso-emails'),
@@ -173,23 +171,15 @@ class PFP_Gateway_Invoice extends WC_Payment_Gateway
      */
     public function get_icon()
     {
-        $icon_url = trim($this->get_option('icon_url'));
-        if (!empty($icon_url)) {
-            $response = wp_remote_head($icon_url, array('timeout' => 2));
-            if (!is_wp_error($response)) {
-                $code = wp_remote_retrieve_response_code($response);
-                if ($code >= 200 && $code < 400) {
-                    $html = '<img src="' . esc_url($icon_url) . '" alt="" style="max-height:1em;width:auto;" />';
-                    return apply_filters('woocommerce_gateway_icon', $html, $this->id);
-                }
-            }
-        }
-
-        $relative = '../assets/img/qr-gateway-icon.png';
-        $path     = plugin_dir_path(__FILE__) . $relative;
+        $relative    = 'assets/img/qr-gateway-icon.png';
+        $plugin_file = dirname(__DIR__) . '/bypierofracasso-woocommerce-emails.php';
+        $path        = plugin_dir_path($plugin_file) . $relative;
         if (file_exists($path)) {
-            $url  = plugins_url($relative, __FILE__);
-            $html = '<img src="' . esc_url($url) . '" alt="" style="max-height:1em;width:auto;" />';
+            $url  = plugin_dir_url($plugin_file) . $relative;
+            $html = sprintf(
+                '<img src="%s" alt="" aria-hidden="true" width="32" height="32" style="height:1em;width:auto;vertical-align:middle;" />',
+                esc_url($url)
+            );
             return apply_filters('woocommerce_gateway_icon', $html, $this->id);
         }
 


### PR DESCRIPTION
## Summary
- support a local PNG icon for the Swiss QR invoice gateway with SVG fallback
- show admin help text about placing a custom icon file
- bump version to 1.2.3 and ensure assets/img folder ships in releases

## Testing
- `php -l bypierofracasso-woocommerce-emails.php`
- `php -l includes/class-pfp-gateway-invoice.php`
- `composer validate --strict`


------
https://chatgpt.com/codex/tasks/task_e_68bfef388e688323ad09414671a41b48