### PR TITLE
Harden invoice gateway registration and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.6-hotfix] - 2025-09-14
+### Changed
+- Hardened Classic/Blocks registration using official WooCommerce hooks; added admin-only instrumentation; kept IBAN rules.
+
 ## [1.2.6] - 2025-09-14
 ### Added
 - Added WooCommerce Blocks checkout support for the Invoice gateway.

--- a/includes/class-pfp-invoice-blocks.php
+++ b/includes/class-pfp-invoice-blocks.php
@@ -12,35 +12,96 @@ class PFP_Invoice_Blocks extends AbstractPaymentMethodType
     /** @var array */
     protected $settings = array();
 
-    public function get_name()
+    protected function get_gateway_id()
     {
-        return 'pfp_invoice';
+        return defined('PFP_GATEWAY_ID') ? PFP_GATEWAY_ID : 'pfp_invoice';
     }
 
-    public function initialize()
+    protected function is_logging_enabled()
     {
-        $this->settings = get_option('woocommerce_pfp_invoice_settings', array());
+        return \function_exists('bypf_invoice_logging_enabled') && \bypf_invoice_logging_enabled();
     }
 
-    public function is_active()
+    protected function evaluate_is_active($log_details = true)
     {
+        $log_enabled = $log_details && $this->is_logging_enabled();
+
         $enabled = isset($this->settings['enabled']) && 'yes' === $this->settings['enabled'];
+        if ($log_enabled) {
+            \bypf_invoice_log_admin('Blocks is_active(): enabled = ' . ($enabled ? 'yes' : 'no'));
+        }
         if (!$enabled) {
+            if ($log_enabled) {
+                \bypf_invoice_log_admin('Blocks is_active(): returning false because gateway is disabled.');
+            }
             return false;
         }
 
-        if ('CHF' !== get_woocommerce_currency()) {
+        $currency = \function_exists('get_woocommerce_currency') ? get_woocommerce_currency() : '';
+        if ($log_enabled) {
+            \bypf_invoice_log_admin('Blocks is_active(): store currency = ' . $currency);
+        }
+        if ('CHF' !== $currency) {
+            if ($log_enabled) {
+                \bypf_invoice_log_admin('Blocks is_active(): returning false due to non-CHF currency.');
+            }
             return false;
         }
 
-        if (isset($this->settings['only_ch_li']) && 'yes' === $this->settings['only_ch_li']) {
-            $base = wc_get_base_location();
-            if (!in_array($base['country'], array('CH', 'LI'), true)) {
+        $restrict = isset($this->settings['only_ch_li']) && 'yes' === $this->settings['only_ch_li'];
+        if ($log_enabled) {
+            \bypf_invoice_log_admin('Blocks is_active(): CH/LI restriction = ' . ($restrict ? 'enabled' : 'disabled'));
+        }
+
+        if ($restrict) {
+            $country = '';
+            if (\function_exists('WC')) {
+                $customer = \WC()->customer;
+                if ($customer) {
+                    $country = $customer->get_billing_country();
+                    if (empty($country)) {
+                        $country = $customer->get_shipping_country();
+                    }
+                }
+            }
+
+            if ($log_enabled) {
+                \bypf_invoice_log_admin('Blocks is_active(): matched customer country = ' . ($country ?: '(empty)'));
+            }
+
+            if (!empty($country) && !in_array($country, array('CH', 'LI'), true)) {
+                if ($log_enabled) {
+                    \bypf_invoice_log_admin('Blocks is_active(): returning false due to country restriction.');
+                }
                 return false;
             }
         }
 
+        if ($log_enabled) {
+            \bypf_invoice_log_admin('Blocks is_active(): final result = true.');
+        }
+
         return true;
+    }
+
+    public function get_name()
+    {
+        return $this->get_gateway_id();
+    }
+
+    public function initialize()
+    {
+        $this->settings = get_option('woocommerce_' . $this->get_gateway_id() . '_settings', array());
+
+        if ($this->is_logging_enabled()) {
+            $active = $this->evaluate_is_active(false);
+            \bypf_invoice_log_admin('Blocks initialize(): is_active = ' . ($active ? 'true' : 'false'));
+        }
+    }
+
+    public function is_active()
+    {
+        return $this->evaluate_is_active(true);
     }
 
     public function get_payment_method_script_handles()


### PR DESCRIPTION
## Summary
- add a single PFP_GATEWAY_ID constant and admin-only invoice logging helpers, then register the classic and Blocks gateways via official WooCommerce hooks with compatibility fallbacks
- tighten PFP_Gateway_Invoice availability checks to log every condition, expose the last failure reasons, update diagnostics, and reuse the shared gateway ID
- refresh the Blocks integration to mirror classic configuration checks, emit initialization logs, and read gateway settings via the shared identifier; bump the plugin version and changelog to 1.2.6-hotfix

## Testing
- php -l bypierofracasso-woocommerce-emails.php
- php -l includes/class-pfp-gateway-invoice.php
- php -l includes/class-pfp-invoice-blocks.php

------
https://chatgpt.com/codex/tasks/task_e_68c99f0d15248323b6ad163a073894b3