### PR TITLE
Ensure invoice gateway registers in Classic and Blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.6.2] - 2025-09-14
+### Changed
+- Hardened Classic/Blocks registration using official WooCommerce APIs.
+- Ensured supports = products and unified gateway ID.
+- Added admin-only diagnostics for availability and blocks activation.
+- No icons added.
+
 ## [1.2.6-hotfix] - 2025-09-14
 ### Changed
 - Hardened Classic/Blocks registration using official WooCommerce hooks; added admin-only instrumentation; kept IBAN rules.

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -1,20 +1,17 @@
-(function () {
-    var wc = window.wc || {};
-    var registry = wc.wcBlocksRegistry || {};
-    var registerPaymentMethod = registry.registerPaymentMethod;
-    var __ = window.wp && window.wp.i18n && typeof window.wp.i18n.__ === 'function'
-        ? window.wp.i18n.__
-        : function (text) {
-            return text;
-        };
+(function() {
+  const registry = window.wc && window.wc.wcBlocksRegistry ? window.wc.wcBlocksRegistry : {};
+  const registerPaymentMethod = registry.registerPaymentMethod;
+  if (typeof registerPaymentMethod !== 'function') {
+    return;
+  }
 
-    if (typeof registerPaymentMethod !== 'function') {
-        return;
-    }
-
-    registerPaymentMethod({
-        name: 'pfp_invoice',
-        title: __('Rechnung (Swiss QR)', 'piero-fracasso-emails'),
-        description: __('Pay via Swiss QR invoice.', 'piero-fracasso-emails'),
-    });
+  registerPaymentMethod({
+    name: 'pfp_invoice',
+    canMakePayment: () => true,
+    edit: () => null,
+    content: () => null,
+    label: window.pfpInvoiceLabel || 'Invoice (Swiss QR)',
+    ariaLabel: window.pfpInvoiceLabel || 'Invoice (Swiss QR)',
+    supports: { features: [] }
+  });
 })();


### PR DESCRIPTION
## Summary
- bump the plugin to 1.2.6.2 and register the invoice gateway through official WooCommerce hooks with a front-end blocks script
- ensure the gateway class always uses the shared ID, supports products, and logs deterministic availability checks
- align the blocks integration and client script with the classic rules while adding admin diagnostics and changelog notes

## Testing
- php -l bypierofracasso-woocommerce-emails.php
- php -l includes/class-pfp-gateway-invoice.php
- php -l includes/class-pfp-invoice-blocks.php

------
https://chatgpt.com/codex/tasks/task_e_68c9aab206d8832394e5dc8a011f5c18