### PR TITLE
Defer translations and add legacy detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.6.5
+- Fix: Deferred all translations to post-init usage to satisfy WP 6.7+ i18n timing.
+- Add: Admin legacy detector to warn when an old plugin version is loaded in parallel.
+- Chore: Reduced repetitive debug logs (product type selector, email registry).
+
 ## [1.2.6.4] - 2025-09-16
 ### Changed
 - Refactor: unified all PHP/JS strings to text domain `bypierofracasso-woocommerce-emails`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Piero Fracasso Perfumes WooCommerce Emails
 
-**Stable tag:** 1.2.6.4
+**Stable tag:** 1.2.6.5
 
 ## Overview
 The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress plugin designed to enhance the email functionality of WooCommerce for the Piero Fracasso Perfumes online store. It introduces custom order statuses, corresponding email notifications, and overrides default WooCommerce email templates with branded versions. The plugin also disables unnecessary default WooCommerce emails to streamline notifications.
@@ -57,7 +57,7 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
 The plugin replaces the legacy *JimSoft QR-Invoice* extension. If that plugin is active, a warning is shown; please deactivate JimSoft to avoid conflicts.
 
 ### Deployment
-WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.6.4`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
+WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.6.5`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
 
 The released ZIP now includes the `vendor/` directory, so no Composer installation is required on production systems.
 

--- a/bypierofracasso-woocommerce-emails.php
+++ b/bypierofracasso-woocommerce-emails.php
@@ -4,7 +4,7 @@ Plugin Name: Piero Fracasso Perfumes WooCommerce Emails
 Plugin URI: https://bypierofracasso.com/
 Description: Steuert alle WooCommerce-E-Mails und deaktiviert nicht benötigte Standardmails.
 
-Version: 1.2.6.4
+Version: 1.2.6.5
 
 Author: Piero Fracasso Perfumes
 Author URI: https://bypierofracasso.com/
@@ -17,13 +17,31 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('BYPF_EMAILS_VERSION', '1.2.6.4');
+define('BYPF_EMAILS_VERSION', '1.2.6.5');
 define('PFP_VERSION', BYPF_EMAILS_VERSION);
 define('PFP_MAIN_FILE', __FILE__);
 define('PFP_GATEWAY_ID', 'pfp_invoice');
 
 function bypf_log($message, $level = 'debug')
 {
+    static $once_per_request = array();
+
+    $limited_messages = array(
+        'perfume_sampler' => "Added \"Perfume Sampler\" to product type selector.",
+        'email_classes'   => 'Registered email classes'
+    );
+
+    foreach ($limited_messages as $key => $needle) {
+        if (strpos($message, $needle) !== false) {
+            if (isset($once_per_request[$key])) {
+                return;
+            }
+
+            $once_per_request[$key] = true;
+            break;
+        }
+    }
+
     if (!defined('WP_DEBUG') || !WP_DEBUG) {
         return;
     }
@@ -134,6 +152,12 @@ function bypf_emails_activation_notice()
 
 register_activation_hook(__FILE__, 'bypf_emails_activation');
 add_action('admin_notices', 'bypf_emails_activation_notice');
+
+require_once plugin_dir_path(__FILE__) . 'includes/class-pfp-legacy-detector.php';
+
+if (class_exists('PFP_Legacy_Detector')) {
+    PFP_Legacy_Detector::register();
+}
 
 // Debug: Confirm plugin is active on admin page loads
 function bypierofracasso_debug_plugin_active()

--- a/includes/class-email-manager.php
+++ b/includes/class-email-manager.php
@@ -34,7 +34,11 @@ class PFP_Email_Manager {
         $email_classes['customer_payment_failed'] = new WC_Email_Customer_Payment_Failed();
 
         // Debug: Log the registered email classes
-        bypf_log('Registered email classes: ' . implode(', ', array_keys($email_classes)));
+        static $registered_logged = false;
+        if (!$registered_logged) {
+            bypf_log('Registered email classes: ' . implode(', ', array_keys($email_classes)));
+            $registered_logged = true;
+        }
 
         if (isset($email_classes['WC_Email_Customer_Invoice'])) {
             $email_classes['WC_Email_Customer_Invoice']->template_base = plugin_dir_path(__FILE__) . '../templates/emails/';

--- a/includes/class-pfp-gateway-invoice.php
+++ b/includes/class-pfp-gateway-invoice.php
@@ -8,6 +8,10 @@ if (!defined('ABSPATH')) {
  */
 class PFP_Gateway_Invoice extends WC_Payment_Gateway
 {
+    private const DEFAULT_TITLE = 'Invoice (Swiss QR)';
+
+    private const DEFAULT_METHOD_DESCRIPTION = 'This payment method appears only when the store currency is CHF and can optionally be limited to billing addresses in Switzerland or Liechtenstein.';
+
     /**
      * Reasons why the gateway is unavailable.
      *
@@ -21,11 +25,11 @@ class PFP_Gateway_Invoice extends WC_Payment_Gateway
     public function __construct()
     {
         $this->id                 = PFP_GATEWAY_ID;
-        $this->method_title       = __('Rechnung (Swiss QR)', 'bypierofracasso-woocommerce-emails');
-        $this->method_description = __('Diese Zahlungsmethode erscheint nur bei Währung CHF und (optional) für Adressen in CH oder LI.', 'bypierofracasso-woocommerce-emails');
-        $this->title              = __('Rechnung (Swiss QR)', 'bypierofracasso-woocommerce-emails');
-        $this->has_fields = false;
-        $this->supports   = array('products');
+        $this->method_title       = self::DEFAULT_TITLE;
+        $this->method_description = self::DEFAULT_METHOD_DESCRIPTION;
+        $this->title              = self::DEFAULT_TITLE;
+        $this->has_fields         = false;
+        $this->supports           = array('products');
 
         $this->init_form_fields();
         $this->init_settings();
@@ -36,6 +40,66 @@ class PFP_Gateway_Invoice extends WC_Payment_Gateway
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
         add_action('woocommerce_review_order_after_payment', array($this, 'maybe_render_checkout_diagnostics'));
         add_filter('woocommerce_settings_api_sanitized_fields_' . $this->id, array($this, 'sanitize_admin_settings'));
+    }
+
+    /**
+     * Get the translated gateway title used in settings screens.
+     */
+    public function get_method_title()
+    {
+        $title = $this->method_title;
+
+        if ($title === self::DEFAULT_TITLE) {
+            $title = __('Invoice (Swiss QR)', 'bypierofracasso-woocommerce-emails');
+        }
+
+        return apply_filters('woocommerce_gateway_title', $title, $this->id);
+    }
+
+    /**
+     * Get the translated gateway title shown at checkout.
+     */
+    public function get_title()
+    {
+        $title = $this->title;
+
+        if ($title === self::DEFAULT_TITLE) {
+            $title = __('Invoice (Swiss QR)', 'bypierofracasso-woocommerce-emails');
+        }
+
+        return apply_filters('woocommerce_gateway_title', $title, $this->id);
+    }
+
+    /**
+     * Get the translated description used in admin screens.
+     */
+    public function get_method_description()
+    {
+        $description = $this->method_description;
+
+        if ($description === self::DEFAULT_METHOD_DESCRIPTION) {
+            $description = __('This payment method appears only when the store currency is CHF and can optionally be limited to billing addresses in Switzerland or Liechtenstein.', 'bypierofracasso-woocommerce-emails');
+        }
+
+        return $description;
+    }
+
+    /**
+     * Get the translated description shown to the customer.
+     */
+    public function get_description()
+    {
+        $description = $this->description;
+
+        if ('' === $description || null === $description) {
+            $description = $this->method_description;
+        }
+
+        if ($description === self::DEFAULT_METHOD_DESCRIPTION) {
+            $description = __('This payment method appears only when the store currency is CHF and can optionally be limited to billing addresses in Switzerland or Liechtenstein.', 'bypierofracasso-woocommerce-emails');
+        }
+
+        return apply_filters('woocommerce_gateway_description_' . $this->id, $description, $this);
     }
 
     /**

--- a/includes/class-pfp-legacy-detector.php
+++ b/includes/class-pfp-legacy-detector.php
@@ -1,0 +1,80 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class PFP_Legacy_Detector
+{
+    /**
+     * Tracks whether the legacy warning has already been handled during the current request.
+     *
+     * @var bool
+     */
+    private $legacy_detected = false;
+
+    /**
+     * Register the detector on plugins_loaded.
+     */
+    public static function register()
+    {
+        $detector = new self();
+        add_action('plugins_loaded', array($detector, 'maybe_warn'), 20);
+    }
+
+    /**
+     * Check for legacy plugin artefacts and display/log warnings when found.
+     */
+    public function maybe_warn()
+    {
+        if (!$this->is_legacy_present()) {
+            return;
+        }
+
+        if (!$this->legacy_detected) {
+            bypf_log('[PFP] Legacy plugin detected alongside current version.', 'warning');
+            $this->legacy_detected = true;
+        }
+
+        if (!is_admin()) {
+            return;
+        }
+
+        if (!function_exists('current_user_can') || !current_user_can('manage_options')) {
+            return;
+        }
+
+        add_action('admin_notices', array($this, 'render_notice'));
+    }
+
+    /**
+     * Identify artefacts left by the legacy plugin.
+     *
+     * @return bool
+     */
+    private function is_legacy_present()
+    {
+        if (class_exists('byPieroFracasso_Email_Manager')) {
+            return true;
+        }
+
+        if (defined('BYPF_EMAIL_MANAGER_VERSION')) {
+            return true;
+        }
+
+        if (function_exists('bypierofracasso_emails_init')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Render the admin notice warning about the legacy plugin.
+     */
+    public function render_notice()
+    {
+        $message = __('Two versions of the Emails plugin are active (legacy + current). Please deactivate and remove the legacy plugin to avoid duplicate hooks and errors.', 'bypierofracasso-woocommerce-emails');
+
+        echo '<div class="notice notice-error is-dismissible"><p>' . esc_html($message) . '</p></div>';
+    }
+}

--- a/includes/class-wc-email-customer-invoice.php
+++ b/includes/class-wc-email-customer-invoice.php
@@ -7,8 +7,8 @@ class WC_Email_Customer_Invoice extends WC_Email {
     public function __construct() {
         $this->id = 'customer_invoice';
         $this->customer_email = true;
-        $this->title = __('Customer Invoice', 'bypierofracasso-woocommerce-emails');
-        $this->description = __('Sent to customers with invoice details.', 'bypierofracasso-woocommerce-emails');
+        $this->title = 'Customer Invoice';
+        $this->description = 'Sent to customers with invoice details.';
         $this->template_base = plugin_dir_path(__FILE__) . '../templates/emails/';
         $this->template_html = 'customer-invoice.php';
         $this->template_plain = 'plain/customer-invoice.php'; // Added
@@ -19,6 +19,14 @@ class WC_Email_Customer_Invoice extends WC_Email {
 
         // Call parent constructor
         parent::__construct();
+    }
+
+    public function get_title() {
+        return apply_filters('woocommerce_email_title_' . $this->id, __($this->title, 'bypierofracasso-woocommerce-emails'), $this);
+    }
+
+    public function get_description() {
+        return __($this->description, 'bypierofracasso-woocommerce-emails');
     }
 
     public function trigger($order_id, $order = false) {

--- a/includes/class-wc-email-customer-payment-failed.php
+++ b/includes/class-wc-email-customer-payment-failed.php
@@ -7,8 +7,8 @@ class WC_Email_Customer_Payment_Failed extends WC_Email {
     public function __construct() {
         $this->id = 'customer_payment_failed';
         $this->customer_email = true;
-        $this->title = __('Customer Payment Failed', 'bypierofracasso-woocommerce-emails');
-        $this->description = __('Sent to customers when payment fails for an order.', 'bypierofracasso-woocommerce-emails');
+        $this->title = 'Customer Payment Failed';
+        $this->description = 'Sent to customers when payment fails for an order.';
         $this->template_base = plugin_dir_path(__FILE__) . '../templates/emails/';
         $this->template_html = 'customer-payment-failed.php';
         $this->template_plain = 'plain/customer-payment-failed.php'; // Added
@@ -18,6 +18,14 @@ class WC_Email_Customer_Payment_Failed extends WC_Email {
         );
 
         parent::__construct();
+    }
+
+    public function get_title() {
+        return apply_filters('woocommerce_email_title_' . $this->id, __($this->title, 'bypierofracasso-woocommerce-emails'), $this);
+    }
+
+    public function get_description() {
+        return __($this->description, 'bypierofracasso-woocommerce-emails');
     }
 
     public function trigger($order_id, $order = false) {

--- a/includes/class-wc-email-order-received.php
+++ b/includes/class-wc-email-order-received.php
@@ -8,10 +8,10 @@ class WC_Email_Order_Received extends WC_Email
     public function __construct()
     {
         $this->id = 'order_received';
-        $this->title = __('Bestellung erhalten', 'bypierofracasso-woocommerce-emails');
-        $this->description = __('Diese E-Mail wird gesendet, wenn eine Bestellung aufgegeben wurde.', 'bypierofracasso-woocommerce-emails');
-        $this->heading = __('Vielen Dank für deine Bestellung!', 'bypierofracasso-woocommerce-emails');
-        $this->subject = __('Deine Bestellung bei Piero Fracasso Perfumes wurde erhalten', 'bypierofracasso-woocommerce-emails');
+        $this->title = 'Bestellung erhalten';
+        $this->description = 'Diese E-Mail wird gesendet, wenn eine Bestellung aufgegeben wurde.';
+        $this->heading = 'Vielen Dank für deine Bestellung!';
+        $this->subject = 'Deine Bestellung bei Piero Fracasso Perfumes wurde erhalten';
 
         $this->template_html = 'customer-order-received.php'; // Fixed path
         $this->template_plain = 'plain/customer-order-received.php'; // Fixed path
@@ -21,6 +21,40 @@ class WC_Email_Order_Received extends WC_Email
         add_action('woocommerce_order_status_changed', array($this, 'bpf_handle_custom_email_trigger'), 9999, 4);
 
         parent::__construct();
+    }
+
+    public function get_title()
+    {
+        return apply_filters('woocommerce_email_title_' . $this->id, __($this->title, 'bypierofracasso-woocommerce-emails'), $this);
+    }
+
+    public function get_description()
+    {
+        return __($this->description, 'bypierofracasso-woocommerce-emails');
+    }
+
+    public function get_heading()
+    {
+        $heading = $this->format_string(__($this->heading, 'bypierofracasso-woocommerce-emails'));
+
+        return apply_filters('woocommerce_email_heading_' . $this->id, $heading, $this->object, $this);
+    }
+
+    public function get_subject()
+    {
+        $subject = $this->format_string(__($this->subject, 'bypierofracasso-woocommerce-emails'));
+
+        return apply_filters('woocommerce_email_subject_' . $this->id, $subject, $this->object, $this);
+    }
+
+    public function get_default_subject()
+    {
+        return __('Deine Bestellung bei Piero Fracasso Perfumes wurde erhalten', 'bypierofracasso-woocommerce-emails');
+    }
+
+    public function get_default_heading()
+    {
+        return __('Vielen Dank für deine Bestellung!', 'bypierofracasso-woocommerce-emails');
     }
 
     // When order status changed

--- a/includes/class-wc-email-pending-order.php
+++ b/includes/class-wc-email-pending-order.php
@@ -8,10 +8,10 @@ class WC_Email_Pending_Order extends WC_Email
     public function __construct()
     {
         $this->id = 'pending_order';
-        $this->title = __('Payment pending', 'bypierofracasso-woocommerce-emails');
-        $this->description = __('This email is sent when an order is marked as “payment pending”.', 'bypierofracasso-woocommerce-emails');
-        $this->heading = __('Please transfer the amount by QR bank payment', 'bypierofracasso-woocommerce-emails');
-        $this->subject = __('Your order with Piero Fracasso Perfumes - Payment pending', 'bypierofracasso-woocommerce-emails');
+        $this->title = 'Payment pending';
+        $this->description = 'This email is sent when an order is marked as “payment pending”.';
+        $this->heading = 'Please transfer the amount by QR bank payment';
+        $this->subject = 'Your order with Piero Fracasso Perfumes - Payment pending';
 
         $this->template_html = 'customer-pending-order.php'; // Fixed path
         $this->template_plain = 'plain/customer-pending-order.php'; // Fixed path
@@ -21,6 +21,40 @@ class WC_Email_Pending_Order extends WC_Email
         add_action('woocommerce_order_status_changed', array($this, 'bpf_handle_custom_email_trigger'), 9999, 4);
 
         parent::__construct();
+    }
+
+    public function get_title()
+    {
+        return apply_filters('woocommerce_email_title_' . $this->id, __($this->title, 'bypierofracasso-woocommerce-emails'), $this);
+    }
+
+    public function get_description()
+    {
+        return __($this->description, 'bypierofracasso-woocommerce-emails');
+    }
+
+    public function get_heading()
+    {
+        $heading = $this->format_string(__($this->heading, 'bypierofracasso-woocommerce-emails'));
+
+        return apply_filters('woocommerce_email_heading_' . $this->id, $heading, $this->object, $this);
+    }
+
+    public function get_subject()
+    {
+        $subject = $this->format_string(__($this->subject, 'bypierofracasso-woocommerce-emails'));
+
+        return apply_filters('woocommerce_email_subject_' . $this->id, $subject, $this->object, $this);
+    }
+
+    public function get_default_subject()
+    {
+        return __('Your order with Piero Fracasso Perfumes - Payment pending', 'bypierofracasso-woocommerce-emails');
+    }
+
+    public function get_default_heading()
+    {
+        return __('Please transfer the amount by QR bank payment', 'bypierofracasso-woocommerce-emails');
     }
 
     // When order status changed

--- a/includes/class-wc-email-ready-for-pickup.php
+++ b/includes/class-wc-email-ready-for-pickup.php
@@ -9,8 +9,8 @@ class WC_Email_Ready_For_Pickup extends WC_Email
     public function __construct()
     {
         $this->id = 'wc_email_ready_for_pickup';
-        $this->title = __('Ready for Pickup', 'bypierofracasso-woocommerce-emails');
-        $this->description = __('Sent when an order is marked as Ready for Pickup.', 'bypierofracasso-woocommerce-emails');
+        $this->title = 'Ready for Pickup';
+        $this->description = 'Sent when an order is marked as Ready for Pickup.';
         $this->template_html = 'customer-order-ready-for-pickup.php';
         $this->template_plain = 'plain/ready-for-pickup.php';
         $this->template_base = plugin_dir_path(__FILE__) . '../templates/emails/';
@@ -24,6 +24,16 @@ class WC_Email_Ready_For_Pickup extends WC_Email
         add_action('woocommerce_order_status_changed', array($this, 'bpf_handle_custom_email_trigger'), 9999, 4);
 
         parent::__construct();
+    }
+
+    public function get_title()
+    {
+        return apply_filters('woocommerce_email_title_' . $this->id, __($this->title, 'bypierofracasso-woocommerce-emails'), $this);
+    }
+
+    public function get_description()
+    {
+        return __($this->description, 'bypierofracasso-woocommerce-emails');
     }
 
     // When order status changed

--- a/includes/class-wc-email-shipped-order.php
+++ b/includes/class-wc-email-shipped-order.php
@@ -9,8 +9,8 @@ class WC_Email_Shipped_Order extends WC_Email
     public function __construct()
     {
         $this->id = 'wc_email_shipped_order';
-        $this->title = __('Shipped Order', 'bypierofracasso-woocommerce-emails');
-        $this->description = __('Sent when an order is marked as Shipped.', 'bypierofracasso-woocommerce-emails');
+        $this->title = 'Shipped Order';
+        $this->description = 'Sent when an order is marked as Shipped.';
         $this->template_html = 'customer-order-shipped.php';
         $this->template_plain = 'plain/customer-order-shipped.php';
         $this->template_base = plugin_dir_path(__FILE__) . '../templates/emails/';
@@ -24,6 +24,16 @@ class WC_Email_Shipped_Order extends WC_Email
         add_action('woocommerce_order_status_changed', array($this, 'bpf_handle_custom_email_trigger'), 9999, 4);
 
         parent::__construct();
+    }
+
+    public function get_title()
+    {
+        return apply_filters('woocommerce_email_title_' . $this->id, __($this->title, 'bypierofracasso-woocommerce-emails'), $this);
+    }
+
+    public function get_description()
+    {
+        return __($this->description, 'bypierofracasso-woocommerce-emails');
     }
 
     // When order status changed


### PR DESCRIPTION
## Summary
- defer translation calls in payment gateway and email classes so constructors only use raw strings while getters provide localized text
- add a legacy plugin detector that logs a warning and surfaces an admin notice when the old extension is loaded alongside the new one
- limit noisy debug messages to once per request and bump the plugin version to 1.2.6.5 with updated changelog/readme

## Testing
- php -l bypierofracasso-woocommerce-emails.php
- php -l includes/class-email-manager.php
- php -l includes/class-pfp-gateway-invoice.php
- php -l includes/class-wc-email-customer-invoice.php
- php -l includes/class-wc-email-customer-payment-failed.php
- php -l includes/class-wc-email-order-received.php
- php -l includes/class-wc-email-pending-order.php
- php -l includes/class-wc-email-ready-for-pickup.php
- php -l includes/class-wc-email-shipped-order.php
- php -l includes/class-pfp-legacy-detector.php

------
https://chatgpt.com/codex/tasks/task_e_68ca6b000e8083239c6eaf4a7276b18d