### PR TITLE
Ensure invoice blocks script enqueues for 1.2.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.6.6
+- Fix: Blocks checkout now enqueues the gateway script reliably; aligned PHP get_name() and JS registration name; added robust dependencies and fallback enqueue on `woocommerce_blocks_enqueue_payment_method_type_scripts`.
+- Tweak: JS `canMakePayment()` simplified to true (server-side availability already enforced).
+
 ## 1.2.6.5
 - Fix: Woo Blocks legacy registration now supports the modern action signature (PaymentMethodRegistry).
 - Fix: Deferred all translations to post-init usage to satisfy WP 6.7+ i18n timing.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Piero Fracasso Perfumes WooCommerce Emails
 
-**Stable tag:** 1.2.6.5
+**Stable tag:** 1.2.6.6
 
 ## Overview
 The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress plugin designed to enhance the email functionality of WooCommerce for the Piero Fracasso Perfumes online store. It introduces custom order statuses, corresponding email notifications, and overrides default WooCommerce email templates with branded versions. The plugin also disables unnecessary default WooCommerce emails to streamline notifications.
@@ -57,7 +57,7 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
 The plugin replaces the legacy *JimSoft QR-Invoice* extension. If that plugin is active, a warning is shown; please deactivate JimSoft to avoid conflicts.
 
 ### Deployment
-WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.6.5`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
+WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.6.6`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
 
 The released ZIP now includes the `vendor/` directory, so no Composer installation is required on production systems.
 

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -1,17 +1,48 @@
-( function() {
+(function () {
+  const registerPaymentMethod =
+    window?.wc?.blocksRegistry?.registerPaymentMethod ||
+    window?.wc?.wcBlocksRegistry?.registerPaymentMethod ||
+    window?.wc?.blocksCheckout?.registerPaymentMethod;
+
+  const { createElement } = window.wp?.element || {};
   const { __ } = window.wp?.i18n || {};
-  const reg = window?.wc?.wcBlocksRegistry?.registerPaymentMethod
-    || ( window?.wc?.blocksCheckout && window.wc.blocksCheckout.registerPaymentMethod );
-  if ( ! reg ) {
+  const { decodeEntities } = window.wp?.htmlEntities || {};
+
+  if (typeof registerPaymentMethod !== 'function' || typeof createElement !== 'function') {
     return;
   }
-  reg( {
-    name: 'pfp_invoice',
+
+  const name = 'pfp_invoice';
+  const labelText = __
+    ? __('Invoice (Swiss QR)', 'bypierofracasso-woocommerce-emails')
+    : 'Invoice (Swiss QR)';
+  const contentText = __
+    ? __('You will receive a QR invoice as PDF after placing the order.', 'bypierofracasso-woocommerce-emails')
+    : 'You will receive a QR invoice as PDF after placing the order.';
+  const ariaLabel = typeof decodeEntities === 'function' ? decodeEntities(labelText) : labelText;
+
+  const Label = ({ PaymentMethodLabel }) => {
+    if (PaymentMethodLabel) {
+      return createElement(PaymentMethodLabel, {
+        text: labelText,
+      });
+    }
+
+    return createElement('span', null, labelText);
+  };
+
+  const Content = () =>
+    createElement('div', null, contentText);
+
+  registerPaymentMethod({
+    name,
+    label: Label,
+    ariaLabel,
+    content: Content,
+    edit: Content,
     canMakePayment: () => true,
-    edit: () => null,
-    content: () => null,
-    ariaLabel: __ ? __( 'Invoice (Swiss QR)', 'bypierofracasso-woocommerce-emails' ) : 'Invoice (Swiss QR)',
-    label: __ ? __( 'Invoice (Swiss QR)', 'bypierofracasso-woocommerce-emails' ) : 'Invoice (Swiss QR)',
-    supports: { features: [] }
-  } );
-} )();
+    supports: {
+      features: ['products'],
+    },
+  });
+})();

--- a/bypierofracasso-woocommerce-emails.php
+++ b/bypierofracasso-woocommerce-emails.php
@@ -4,7 +4,7 @@ Plugin Name: Piero Fracasso Perfumes WooCommerce Emails
 Plugin URI: https://bypierofracasso.com/
 Description: Steuert alle WooCommerce-E-Mails und deaktiviert nicht benötigte Standardmails.
 
-Version: 1.2.6.5
+Version: 1.2.6.6
 
 Author: Piero Fracasso Perfumes
 Author URI: https://bypierofracasso.com/
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('BYPF_EMAILS_VERSION', '1.2.6.5');
+define('BYPF_EMAILS_VERSION', '1.2.6.6');
 define('PFP_VERSION', BYPF_EMAILS_VERSION);
 define('PFP_MAIN_FILE', __FILE__);
 define('PFP_GATEWAY_ID', 'pfp_invoice');
@@ -597,17 +597,35 @@ add_action('init', function () {
     wp_register_script(
         'pfp-invoice-blocks',
         plugins_url('assets/blocks/index.js', PFP_MAIN_FILE),
-        array('wc-blocks-registry', 'wp-element', 'wp-i18n'),
+        array('wc-blocks-registry', 'wp-element', 'wp-i18n', 'wp-html-entities'),
         PFP_VERSION,
         true
     );
 
-    wp_set_script_translations(
-        'pfp-invoice-blocks',
-        'bypierofracasso-woocommerce-emails',
-        plugin_dir_path(PFP_MAIN_FILE) . 'languages'
-    );
+    if (function_exists('wp_set_script_translations')) {
+        wp_set_script_translations(
+            'pfp-invoice-blocks',
+            'bypierofracasso-woocommerce-emails',
+            plugin_dir_path(PFP_MAIN_FILE) . 'languages'
+        );
+    }
 });
+
+add_action('woocommerce_blocks_enqueue_payment_method_type_scripts', function () {
+    if (function_exists('wp_script_is') && wp_script_is('pfp-invoice-blocks', 'enqueued')) {
+        return;
+    }
+
+    if (function_exists('wp_enqueue_script')) {
+        wp_enqueue_script('pfp-invoice-blocks');
+
+        if (function_exists('pfp_log')) {
+            pfp_log('[PFP] enqueued pfp-invoice-blocks');
+        } elseif (function_exists('bypf_invoice_log_admin')) {
+            bypf_invoice_log_admin('enqueued pfp-invoice-blocks');
+        }
+    }
+}, 10);
 
 add_action('woocommerce_blocks_loaded', 'bypf_register_invoice_blocks_integration');
 


### PR DESCRIPTION
## Summary
- bump the plugin to version 1.2.6.6 and document the changes in the changelog/README
- harden the Blocks integration to expose `pfp_invoice` data, keep availability checks, and return the new script handle
- register the Blocks script with updated dependencies, enqueue it as a fallback, and modernize the front-end payment method registration

## Testing
- php -l bypierofracasso-woocommerce-emails.php
- php -l includes/class-pfp-invoice-blocks.php

------
https://chatgpt.com/codex/tasks/task_e_68ca7a334b708323ac6ee18f684e411b