### PR TITLE
Fix invoice order received email dispatch and manual reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
 ## 1.2.6.12
-- Fix: Ensure our “customer_order_received” email is registered, enabled, and always triggered after checkout (idempotent) for all gateways.
-- Feature: Invoice-specific notice and automatic PDF attachment inside the same customer-order-received template.
-- Feature: Manual “Zahlungserinnerung” email with order action; also attaches the invoice PDF for invoice orders.
-- Remove: Legacy customer-invoice template and any triggers.
-- Improve: Align templates with WooCommerce Email HTML Best Practices (preheader, alt text, 600px container, inline CSS, bulletproof buttons, accessibility, RTL/dark-mode resilience) while preserving existing design.
-- Dev: Extended logging for class registration, triggering, recipients and attachment resolution to simplify diagnosis.
+- Fix: Send the customer “Order received” email for invoice checkout flows and invoice status transitions.
+- Fix: Guard access to the email manager when the custom email instance is not initialized yet (prevent PHP warnings).
+- Tweak: Keep the payment reminder manual-only with an updated label and WooCommerce order action.
+- Docs: Clarified behaviour for invoice emails and reminder workflow.
 
 ## 1.2.6.11
 - Change: Always send our “customer-order-received” email after checkout (all gateways) to avoid split workflows.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Piero Fracasso Perfumes WooCommerce Emails
 
-**Stable tag:** 1.2.6.11
+**Stable tag:** 1.2.6.12
 
 ## Overview
 The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress plugin designed to enhance the email functionality of WooCommerce for the Piero Fracasso Perfumes online store. It introduces custom order statuses, corresponding email notifications, and overrides default WooCommerce email templates with branded versions. The plugin also disables unnecessary default WooCommerce emails to streamline notifications.
@@ -12,11 +12,12 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
   - `wc-shipped`: Indicates an order has been shipped.
   - `wc-ready-for-pickup`: Indicates an order is ready for customer pickup.
 - **Custom Email Notifications**:
-  - **Order Received**: Sent when an order status changes to `wc-received`.
+  - **Order Received**: Sent when an order status changes to `wc-received` and automatically triggered for `pfp_invoice` orders right after checkout or when the status moves into `invoice`.
   - **Pending Order**: Sent for orders in `wc-pending-payment` status.
   - **Shipped Order**: Sent when an order status changes to `wc-shipped`.
   - **Ready for Pickup**: Sent when an order status changes to `wc-ready-for-pickup`.
   - **Customer Payment Failed**: Sent when a payment fails.
+  - **Customer Payment Reminder**: Manual-only reminder available as an order action for invoice payments.
 - **Custom Email Templates**:
   - Overrides default WooCommerce email templates with branded versions located in `templates/emails/`.
   - Includes plain text versions in `templates/emails/plain/`.
@@ -39,6 +40,8 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
 - **Custom Statuses**: The plugin automatically adds custom order statuses to WooCommerce. You can set an order to these statuses via the admin panel or programmatically.
 - **Swiss QR Invoice Payment:** Enable the 'Rechnung (Swiss QR)' gateway under WooCommerce > Payments and configure a QR-IBAN or IBAN plus creditor data.
 - **Email Notifications**: Emails are triggered when an order status changes to one of the custom statuses. Ensure the emails are enabled in WooCommerce settings.
+- **Invoice Attachments**: The `pfp_invoice` gateway attaches the generated PDF invoice to the customer order received email and to manually sent reminders.
+- **Reminder Workflow**: Send invoice reminders via the order actions dropdown (`Zahlungserinnerung senden`) on the WooCommerce order screen; the email remains manual-only.
 - **Debugging**:
   - Enable WordPress debugging in `wp-config.php`:
     ```php
@@ -57,7 +60,7 @@ The **Piero Fracasso Perfumes WooCommerce Emails** plugin is a custom WordPress 
 The plugin replaces the legacy *JimSoft QR-Invoice* extension. If that plugin is active, a warning is shown; please deactivate JimSoft to avoid conflicts.
 
 ### Deployment
-WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.6.11`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
+WordPress 5.5+ supports replacing the plugin by uploading a ZIP with the same folder name. Increase the version (currently `1.2.6.12`) so WordPress detects the update. JimSoft can remain installed but must stay deactivated.
 
 The released ZIP now includes the `vendor/` directory, so no Composer installation is required on production systems.
 

--- a/templates/emails/customer-order-received.php
+++ b/templates/emails/customer-order-received.php
@@ -1,272 +1,30 @@
 <?php
 /**
  * Customer Order Received Email
- *
- *
- * @see https://woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
- * @version 1.0.0
  */
 
 if (!defined('ABSPATH')) {
-    exit; // Exit if accessed directly.
+    exit;
 }
-
-$plugin_path = plugin_dir_url(__FILE__) . 'images';
-include(plugin_dir_path(__FILE__) . 'setting-wc-email.php');
 
 do_action('woocommerce_email_header', $email_heading, $email);
 ?>
 
-<!-- Titles : Subtitle Title Button -->
-<table border="0" width="100%" align="center" cellpadding="0" cellspacing="0" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-    <tr>
-        <td align="center" valign="middle" bgcolor="#F1F1F1" class="bg-F1F1F1">
-            <table border="0" width="600" align="center" cellpadding="0" cellspacing="0" class="row table-600" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:600px; width:100%;">
-                <tr>
-                    <td align="center" bgcolor="#4B7BEC" class="bg-4B7BEC">
-                        <table border="0" width="520" align="center" cellpadding="0" cellspacing="0" class="row table-520" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:520px; width:100%;">
-                            <tr>
-                                <td align="center" class="container-padding">
-                                    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-                                        <tr>
-                                            <td class="spacer-30"> </td>
-                                        </tr>
-                                        <tr>
-                                            <td align="center" valign="middle" class="font-primary font-FFFFFF font-16 font-weight-600 pb-5 font-space-0">
-                                                <?php echo __($order_received_subtitle, 'bypierofracasso-woocommerce-emails'); ?>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td align="center" valign="middle" class="font-primary font-FFFFFF font-36 font-weight-400 font-space-0 pb-30">
-                                                <?php echo __($email_heading, 'bypierofracasso-woocommerce-emails'); ?>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td align="center" valign="middle">
-                                                <table border="0" align="center" cellpadding="0" cellspacing="0">
-                                                    <tr>
-                                                        <td align="center" class="bg-FFFFFF block btn border-radius-4">
-                                                            <a href="<?php echo ($order instanceof WC_Order) ? esc_url($order->get_view_order_url()) : '#'; ?>" class="font-primary font-4B7BEC font-14 font-weight-600 font-space-0-5 block btn white-space" style="display:inline-block; padding:12px 28px; background-color:#FFFFFF; color:#4B7BEC; text-decoration:none; border-radius:4px; line-height:1.4; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;">
-                                                                <?php echo __($order_received_btn, 'bypierofracasso-woocommerce-emails'); ?>
-                                                            </a>
-                                                        </td>
-                                                    </tr>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="spacer-15"> </td>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
-<!-- Titles : Subtitle Title Button -->
-
-<!-- Headers : Full Image -->
-<table border="0" width="100%" align="center" cellpadding="0" cellspacing="0" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-    <tr>
-        <td align="center" valign="middle" bgcolor="#F1F1F1" class="bg-F1F1F1">
-            <table border="0" width="600" align="center" cellpadding="0" cellspacing="0" class="row table-600" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:600px; width:100%;">
-                <tr>
-                    <td align="center" bgcolor="#4B7BEC" class="bg-4B7BEC">
-                        <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-                            <tr>
-                                <td align="center">
-                                    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-                                        <tr>
-                                            <td align="center" valign="middle" class="img-responsive">
-                                                <img src="<?php echo esc_url($plugin_path . '/' . $order_received_hero_bg_img); ?>" border="0" width="600" alt="" class="block table-600" style="display:block; width:100%; height:auto; border:0;">
-                                            </td>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
-<!-- Header : Full Image -->
-
-<!-- Contents : Title Description -->
-<table border="0" width="100%" align="center" cellpadding="0" cellspacing="0" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-    <tr>
-        <td align="center" valign="middle" bgcolor="#F1F1F1" class="bg-F1F1F1">
-            <table border="0" width="600" align="center" cellpadding="0" cellspacing="0" class="row table-600" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:600px; width:100%;">
-                <tr>
-                    <td align="center" bgcolor="#FFFFFF" class="bg-FFFFFF">
-                        <table border="0" width="520" align="center" cellpadding="0" cellspacing="0" class="row table-520" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:520px; width:100%;">
-                            <tr>
-                                <td align="center" class="container-padding">
-                                    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-                                        <tr>
-                                            <td class="spacer-30"> </td>
-                                        </tr>
-                                        <tr>
-                                            <td align="left" valign="middle" class="center-text font-primary font-191919 font-18 font-weight-600 font-space-0 pb-20">
-                                                <?php
-                                                if ($order instanceof WC_Order) {
-                                                    echo __($order_received_greeting . " " . esc_html($order->get_billing_first_name()) . ',', 'bypierofracasso-woocommerce-emails');
-                                                } else {
-                                                    echo __($order_received_greeting . " Customer,", 'bypierofracasso-woocommerce-emails');
-                                                }
-                                                ?>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td align="left" valign="middle" class="center-text font-primary font-595959 font-16 font-weight-400 font-space-0 pb-20" style="padding:0px;">
-                                                <?php
-                                                echo __($order_received_message, 'bypierofracasso-woocommerce-emails');
-                                                if (isset($additional_content) && $additional_content) {
-                                                    echo '<br><br>' . wp_kses_post(wptexturize($additional_content));
-                                                }
-                                                if ($order instanceof WC_Order && $order->get_customer_note() != "") {
-                                                    echo __('<br><br> <strong>Note</strong>: ', 'bypierofracasso-woocommerce-emails');
-                                                    echo wp_kses_post($order->get_customer_note());
-                                                }
-                                                ?>
-                                            </td>
-                                        </tr>
-                                        <?php if (isset($order) && $order instanceof WC_Order && 'pfp_invoice' === $order->get_payment_method()) : ?>
-                                        <tr>
-                                            <td>
-                                                <table border="0" width="100%" align="center" cellpadding="0" cellspacing="0" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-                                                    <tr>
-                                                        <td align="center" valign="middle" bgcolor="#F1F1F1" class="bg-F1F1F1">
-                                                            <table border="0" width="520" align="center" cellpadding="0" cellspacing="0" class="row table-520" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:520px; width:100%;">
-                                                                <tr>
-                                                                    <td align="left" class="container-padding center-text font-primary font-191919 font-16 font-weight-400 font-space-0" style="background:#F7F7F7; padding:12px 16px; border-radius:4px;">
-                                                                        <strong><?php echo esc_html__('Die Rechnung finden Sie im Anhang dieser Bestellbestätigung.', 'bypierofracasso-woocommerce-emails'); ?></strong>
-                                                                        <div style="margin-top:6px;">
-                                                                            <?php echo esc_html__('Rechnungsbetrag sofort zahlbar nach Erhalt.', 'bypierofracasso-woocommerce-emails'); ?>
-                                                                        </div>
-                                                                    </td>
-                                                                </tr>
-                                                                <tr><td class="spacer-15">&nbsp;</td></tr>
-                                                            </table>
-                                                        </td>
-                                                    </tr>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                        <?php endif; ?>
-                                        <tr>
-                                            <td class="spacer-15"> </td>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
-<!-- Contents : Title Description -->
-
-<!-- Dividers : Divider -->
-<table border="0" width="100%" align="center" cellpadding="0" cellspacing="0" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-    <tr>
-        <td align="center" valign="middle" bgcolor="#F1F1F1" class="bg-F1F1F1">
-            <table border="0" width="600" align="center" cellpadding="0" cellspacing="0" class="row table-600" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:600px; width:100%;">
-                <tr>
-                    <td align="center" bgcolor="#FFFFFF" class="bg-FFFFFF">
-                        <table border="0" width="520" align="center" cellpadding="0" cellspacing="0" class="row table-520" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:520px; width:100%;">
-                            <tr>
-                                <td align="center" class="container-padding">
-                                    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-                                        <tr>
-                                            <td class="spacer-15"> </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="bg-F1F1F1 spacer-1"> </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="spacer-15"> </td>
-                                        </tr>
-                                            <?php if ($order instanceof WC_Order) : ?>
-                                                <?php
-                                                do_action('woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email);
-                                                do_action('woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email);
-                                                do_action('woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email);
-                                                ?>
-                                            <?php else : ?>
-                                                <tr>
-                                                    <td align="left" class="font-primary font-595959 font-16 font-weight-400">
-                                                        <?php echo __('[Order Details Placeholder]', 'bypierofracasso-woocommerce-emails'); ?>
-                                                    </td>
-                                                </tr>
-                                            </table>
-
-                                        <?php endif; ?>
-                                        <tr>
-                                            <td class="spacer-15"> </td>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
-<!-- Dividers : Divider -->
-
-<!-- Buttons : Button -->
-<table border="0" width="100%" align="center" cellpadding="0" cellspacing="0" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-    <tr>
-        <td align="center" valign="middle" bgcolor="#F1F1F1" class="bg-F1F1F1">
-            <table border="0" width="600" align="center" cellpadding="0" cellspacing="0" class="row table-600" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:600px; width:100%;">
-                <tr>
-                    <td align="center" bgcolor="#FFFFFF" class="bg-FFFFFF">
-                        <table border="0" width="520" align="center" cellpadding="0" cellspacing="0" class="row table-520" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0; max-width:520px; width:100%;">
-                            <tr>
-                                <td align="center" class="container-padding">
-                                    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" class="table-100pc" role="presentation" style="border-collapse:collapse; mso-table-lspace:0; mso-table-rspace:0;">
-                                        <tr>
-                                            <td class="spacer-20"> </td>
-                                        </tr>
-                                        <tr>
-                                            <td align="center" valign="middle">
-                                                <table border="0" align="center" cellpadding="0" cellspacing="0">
-                                                    <tr>
-                                                        <td align="center" class="bg-4B7BEC block btn border-radius-4">
-                                                            <a href="<?php echo ($order instanceof WC_Order) ? esc_url($order->get_view_order_url()) : '#'; ?>" class="font-primary font-FFFFFF font-14 font-weight-600 font-space-0-5 block btn white-space" style="display:inline-block; padding:12px 28px; background-color:#4B7BEC; color:#FFFFFF; text-decoration:none; border-radius:4px; line-height:1.4; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;">
-                                                                <?php echo __($order_received_btn, 'bypierofracasso-woocommerce-emails'); ?>
-                                                            </a>
-                                                        </td>
-                                                    </tr>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="spacer-30"> </td>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
-<!-- Buttons : Button -->
+<?php if (isset($order) && $order instanceof WC_Order && $order->get_payment_method() === 'pfp_invoice') : ?>
+    <p style="margin:0 0 16px;">
+        <?php echo esc_html__('Vielen Dank für Ihre Bestellung. Sie haben Zahlung per Rechnung gewählt. Die Rechnung liegt dieser E-Mail als PDF bei. Zahlungsfrist: 10 Tage.', 'bypierofracasso-woocommerce-emails'); ?>
+    </p>
+<?php else : ?>
+    <p style="margin:0 0 16px;">
+        <?php echo esc_html__('Vielen Dank für Ihre Bestellung. Wir haben Ihre Bestellung erhalten und bearbeiten sie umgehend.', 'bypierofracasso-woocommerce-emails'); ?>
+    </p>
+<?php endif; ?>
 
 <?php
+if (isset($order) && $order instanceof WC_Order) {
+    do_action('woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email);
+    do_action('woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email);
+    do_action('woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email);
+}
+
 do_action('woocommerce_email_footer', $email);
-?>


### PR DESCRIPTION
## Summary
- guard the custom email manager before touching uninitialized mailer instances and move invoice PDF attachments plus reminder order action handling into the manager
- overhaul the customer order received email class to use ID `pfp_email_order_received`, add invoice-aware triggers, and simplify the template content with Woo hooks
- keep the customer payment reminder manual-only with new logging, attach PDFs only for invoice orders, and document the updated workflows while bumping the version docs

## Testing
- php -l bypierofracasso-woocommerce-emails.php
- php -l includes/class-email-manager.php
- php -l includes/class-wc-email-order-received.php
- php -l includes/class-wc-email-customer-payment-reminder.php
- php -l templates/emails/customer-order-received.php

------
https://chatgpt.com/codex/tasks/task_e_68caf1f477cc832388388e28bb664172